### PR TITLE
GDB-5620 Graphdb helm tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,43 @@ Those options are described in the subsection `graphdb.backupRestore.*` and they
 - trigger_restore - a future date at which we want to trigger a restore. Works only with a cluster with workers. For a standalone the restore is called from an init container. Must be given in format DD.MM.YYYY hh:mm
 - restore_from_backup - the name of the backup directory we want to restore. Must be given in format MM-DD-YY-hh-mm, where MM-DD-YY-hh-mm is your backup directory
 
+#### Preload, LoadRDF, Storage tools
+GraphDB's Helm chart supports preload and LoadRDF tools for preloading data. It also supports Storage tool for scanning and repairing data. There are a few options that are used to run the needed commands.
+
+Those options are described in the subsection `graphdb.tools.*` and they are:
+
+- resources - to set the needed resources in order to run the tools. Bear in mind that if you don't give the init containers enough resources, the tools might fail. 
+```bash
+resources:
+  limits:
+    cpu: 4
+    memory: "10Gi"
+  requests:
+    cpu: 4
+    memory: "10Gi"
+```
+- preload - tool to preload data in a chosen repository.
+  - trigger - If trigger is set to true, then the preload tool will be run while initializing the deployment.
+  - flags - options to add to the command. The possible options are "-f", "-p", "-r". If you use the "-f" option, the tool will override the repository and could lose some data.
+  - rdfDataFile - the file that is added in the mounted directory.
+
+For more information about the Preload tool see: https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-preload.html
+
+- loadrdf - tool to preload data in a chosen repository.
+  - trigger - if trigger is set to true, then the loadrdf tool will be run while initializing the deployment.
+  - flags - options to add to the command. The possible options are "-f", "-p". If you use the "-f" option, the tool will override the repository and could lose some data. 
+  - rdfDataFile - the file that is added in the mounted directory.
+
+For more information about the LoadRDF tool see: https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-the-loadrdf-tool.html
+
+- storage_tool - tool for scanning and repairing data.
+  - trigger - if trigger is set to true, then the storage tool will be run while initializing the deployment.
+  - command - the command to run the storage-tool with.
+  - repository - repo to run command on.
+  - options - additional options to run the storage-tool with. 
+
+For more information about the Storage tool see https://graphdb.ontotext.com/documentation/enterprise/storage-tool.html
+
 ### values.yaml
 
 Helm allows you to override values from [values.yaml](values.yaml) in several ways.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,18 @@ about defining resource limits.
 | deployment.storage | string | `"/data"` | The storage place where components will read/write their persistent data in case the default persistent volumes are used. They use the node's file system. |
 | deployment.tls.enabled | bool | `false` | Feature toggle for SSL termination. Disabled by default. |
 | deployment.tls.secretName | string | `nil` | Name of a Kubernetes secret object with the key and certificate. If TLS is enabled, it's required to be provided, depending on the deployment. |
+| graphdb.tools | object | `{"loadrdf":{"flags":"-f","rdfDataFile":"geonames_europe.ttl ","trigger":false},"preload":{"flags":"-f","rdfDataFile":"geonames_europe.ttl ","trigger":true},"storage_tool":{"command":"scan","options":"","repository":"repo-test-1","trigger":false}}` | Tools for loading, scanning and repairing data in repos |
+| graphdb.tools.loadrdf | object | `{"flags":"-f","rdfDataFile":"geonames_europe.ttl ","trigger":false}` | Tool to preload data in a chosen repo https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-the-loadrdf-tool.html |
+| graphdb.tools.loadrdf.flags | string | `"-f"` | Options to add to the command possible flags: -f, -p |
+| graphdb.tools.loadrdf.trigger | bool | `false` | If trigger is set to true, then the loadrdf tool will be run while initializing the deployment Don't forget to add repo config file(should be named config.ttl) and RDF data file to the graphdb-preload-data-pv (default pv is: /data/graphdb-worker-preload-data) |
+| graphdb.tools.preload | object | `{"flags":"-f","rdfDataFile":"geonames_europe.ttl ","trigger":true}` | Tool to preload data in a chosen repo https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-preload.html |
+| graphdb.tools.preload.flags | string | `"-f"` | Options to add to the command possible flags: -f, -p, -r |
+| graphdb.tools.preload.trigger | bool | `true` | If trigger is set to true, then the preload tool will be run while initializing the deployment Don't forget to add repo config file(should be named config.ttl) and RDF data file to the graphdb-preload-data-pv (default pv is: /data/graphdb-worker-preload-data) |
+| graphdb.tools.storage_tool | object | `{"command":"scan","options":"","repository":"repo-test-1","trigger":false}` | Tool for scanning and repairing data See https://graphdb.ontotext.com/documentation/enterprise/storage-tool.html |
+| graphdb.tools.storage_tool.command | string | `"scan"` | commands to run the storage-tool with |
+| graphdb.tools.storage_tool.options | string | `""` | additional options to run the storage-tool with if you want to use the option rebuild with -srcIndex=pso -destIndex=pso or -srcIndex=pso -destIndex=pos, don't forget to make the workers' memory limits 10Gi |
+| graphdb.tools.storage_tool.repository | string | `"repo-test-1"` | repo to run command on |
+| graphdb.tools.storage_tool.trigger | bool | `false` | If trigger is set to true, then the storage tool will be run while initializing the deployment |
 | graphdb.backupRestore.auto_backup | string | `"* 0 * * *"` | Cron Schedule for auto backup. Creates an automatic backup, stored in the backup-pv (default folder - /data/graphdb-backups). The backups are saved in format MM-DD-YYYY-hh-mm TODO: Add PV options for backups |
 | graphdb.backupRestore.backup_max_age | string | `"5"` | Max number of days for backups. |
 | graphdb.backupRestore.backups_count | string | `"5"` | Max number of backup dirs saved. |

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -42,6 +42,10 @@ spec:
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
+        - name: graphdb-worker-preload-data
+          persistentVolumeClaim:
+            claimName: graphdb-worker-preload-data-pvc
+
       {{ if hasKey $.Values.deployment "imagePullSecret" }}
       imagePullSecrets:
         - name: {{ $.Values.deployment.imagePullSecret }}
@@ -122,6 +126,59 @@ spec:
               echo 'Provisioning GraphDB {{ $worker_repo }} repository config.ttl' ;
               cp /tmp/graphdb/config.ttl ./config.ttl ;
               echo 'Done'
+        # LOADRDF TOOL
+        {{- if and (eq $worker_index 1) $.Values.graphdb.tools.loadrdf.trigger }}
+        - name: loadrdf-tool
+          image: {{ $.Values.images.graphdb }}
+          imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          volumeMounts:
+            - name: graphdb-worker-storage
+              mountPath: /opt/graphdb/home
+            - name: graphdb-worker-preload-data
+              mountPath: /tmp/graphdb/
+          command: ['sh', '-c']
+          args:
+            - |
+              cp /opt/graphdb/home/conf/graphdb.license /opt/graphdb/dist/conf/graphdb.license
+              echo "graphdb.home.data = /opt/graphdb/home/data/" >> /opt/graphdb/dist/conf/graphdb.properties
+              /opt/graphdb/dist/bin/loadrdf {{ $.Values.graphdb.tools.loadrdf.flags }} -c /tmp/graphdb/config.ttl -m parallel /tmp/graphdb/{{$.Values.graphdb.tools.preload.rdfDataFile}}
+              echo "preload with loadrdf tool is done"
+          {{- end }}
+        {{- if and (eq $worker_index 1) $.Values.graphdb.tools.preload.trigger }}
+        # PRELOAD TOOL
+        - name: preload-tool
+          image: {{ $.Values.images.graphdb }}
+          imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          volumeMounts:
+            - name: graphdb-worker-storage
+              mountPath: /opt/graphdb/home
+            - name: graphdb-worker-preload-data
+              mountPath: /tmp/graphdb/
+          command: ['sh', '-c']
+          args:
+            - |
+              cp /opt/graphdb/home/conf/graphdb.license /opt/graphdb/dist/conf/graphdb.license
+              echo "graphdb.home.data = /opt/graphdb/home/data/" >> /opt/graphdb/dist/conf/graphdb.properties
+              /opt/graphdb/dist/bin/preload -f -c /tmp/graphdb/config.ttl /tmp/graphdb/{{$.Values.graphdb.tools.preload.rdfDataFile}}
+              mv /opt/graphdb/dist/data/repositories/* /opt/graphdb/home/data
+              echo "preload with preload tool is done"
+        {{- end }}
+        # STORAGE TOOL
+        {{- if and (eq $worker_index 1) $.Values.graphdb.tools.storage_tool.trigger }}
+        - name: storage-tool
+          image: {{ $.Values.images.graphdb }}
+          imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          volumeMounts:
+            - name: graphdb-worker-storage
+              mountPath: /opt/graphdb/home
+          command: ['sh', '-c']
+          args:
+            - |
+              cdate=$(date +'%Y-%m-%d')
+              /opt/graphdb/dist/bin/storage-tool -command={{ $.Values.graphdb.tools.storage_tool.command }} -storage=/opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repo}}/storage >> /opt/graphdb/home/data/storage-tool-${cdate}.log
+        {{- end }}
+
+
 ---
 apiVersion: {{ $.Values.versions.service }}
 kind: Service

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -133,11 +133,11 @@ spec:
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           resources:
             limits:
-              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
-              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+              cpu: {{ $.Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ $.Values.graphdb.tools.resources.limits.memory }}
             requests:
-              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
-              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
+              cpu:  {{ $.Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ $.Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home
@@ -150,7 +150,7 @@ spec:
               echo "graphdb.home.data = /opt/graphdb/home/data/" >> /opt/graphdb/dist/conf/graphdb.properties
               /opt/graphdb/dist/bin/loadrdf {{ $.Values.graphdb.tools.loadrdf.flags }} -c /tmp/graphdb/config.ttl -m parallel /tmp/graphdb/{{$.Values.graphdb.tools.preload.rdfDataFile}}
               echo "preload with loadrdf tool is done"
-          {{- end }}
+              {{- end }}
         {{- if and (eq $worker_index 1) $.Values.graphdb.tools.preload.trigger }}
         # PRELOAD TOOL
         - name: preload-tool
@@ -158,11 +158,11 @@ spec:
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           resources:
             limits:
-              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
-              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+              cpu: {{ $.Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ $.Values.graphdb.tools.resources.limits.memory }}
             requests:
-              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
-              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
+              cpu:  {{ $.Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ $.Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home
@@ -173,8 +173,7 @@ spec:
             - |
               cp /opt/graphdb/home/conf/graphdb.license /opt/graphdb/dist/conf/graphdb.license
               echo "graphdb.home.data = /opt/graphdb/home/data/" >> /opt/graphdb/dist/conf/graphdb.properties
-              /opt/graphdb/dist/bin/preload -f -c /tmp/graphdb/config.ttl /tmp/graphdb/{{$.Values.graphdb.tools.preload.rdfDataFile}}
-              mv /opt/graphdb/dist/data/repositories/* /opt/graphdb/home/data
+              /opt/graphdb/dist/bin/preload {{ $.Values.graphdb.tools.preload.flags }} -c /tmp/graphdb/config.ttl /tmp/graphdb/{{$.Values.graphdb.tools.preload.rdfDataFile}}
               echo "preload with preload tool is done"
         {{- end }}
         # STORAGE TOOL
@@ -184,11 +183,11 @@ spec:
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           resources:
             limits:
-              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
-              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+              cpu: {{ $.Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ $.Values.graphdb.tools.resources.limits.memory }}
             requests:
-              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
-              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
+              cpu:  {{ $.Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ $.Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home
@@ -196,9 +195,18 @@ spec:
           args:
             - |
               cdate=$(date +'%Y-%m-%d')
-              /opt/graphdb/dist/bin/storage-tool -command={{ $.Values.graphdb.tools.storage_tool.command }} -storage=/opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repository}}/storage {{$.Values.graphdb.tools.storage_tool.options}}>> /opt/graphdb/home/data/storage-tool-${cdate}.log
+              if [ -d /opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repository}}/storage ]; then
+                result=$(/opt/graphdb/dist/bin/storage-tool -command={{ $.Values.graphdb.tools.storage_tool.command }} -storage=/opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repository}}/storage {{$.Values.graphdb.tools.storage_tool.options}})
+                echo -e "${result}" >> /opt/graphdb/home/data/storage-tool-${cdate}.log
+                echo -e "${result}"
+                if echo -e "${result}" | grep -qi "inconsistent"
+                then
+                  exit 1
+                fi
+              else
+                echo "The wanted repository does not exist"
+              fi
         {{- end }}
-
 
 ---
 apiVersion: {{ $.Values.versions.service }}

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -131,6 +131,13 @@ spec:
         - name: loadrdf-tool
           image: {{ $.Values.images.graphdb }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          resources:
+            limits:
+              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+            requests:
+              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home
@@ -149,6 +156,13 @@ spec:
         - name: preload-tool
           image: {{ $.Values.images.graphdb }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          resources:
+            limits:
+              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+            requests:
+              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home
@@ -168,6 +182,13 @@ spec:
         - name: storage-tool
           image: {{ $.Values.images.graphdb }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          resources:
+            limits:
+              cpu: {{ .Values.graphdb.tools.resources.limits.cpu }}
+              memory: {{ .Values.graphdb.tools.resources.limits.memory }}
+            requests:
+              cpu:  {{ .Values.graphdb.tools.resources.requests.cpu }}
+              memory:  {{ .Values.graphdb.tools.resources.requests.memory }}
           volumeMounts:
             - name: graphdb-worker-storage
               mountPath: /opt/graphdb/home

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -175,7 +175,7 @@ spec:
           args:
             - |
               cdate=$(date +'%Y-%m-%d')
-              /opt/graphdb/dist/bin/storage-tool -command={{ $.Values.graphdb.tools.storage_tool.command }} -storage=/opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repo}}/storage >> /opt/graphdb/home/data/storage-tool-${cdate}.log
+              /opt/graphdb/dist/bin/storage-tool -command={{ $.Values.graphdb.tools.storage_tool.command }} -storage=/opt/graphdb/home/data/repositories/{{$.Values.graphdb.tools.storage_tool.repository}}/storage {{$.Values.graphdb.tools.storage_tool.options}}>> /opt/graphdb/home/data/storage-tool-${cdate}.log
         {{- end }}
 
 

--- a/templates/persistence/graphdb-preload-data-pv.yaml
+++ b/templates/persistence/graphdb-preload-data-pv.yaml
@@ -1,0 +1,21 @@
+#
+# Default persistence volume for GraphDB workers. Data is stored on the node file system. Suitable
+# for Minikube deployments.
+#
+# Note: Not to be used in production or multi node cluster.
+#
+---
+apiVersion: {{ $.Values.versions.pv }}
+kind: PersistentVolume
+metadata:
+  name: graphdb-worker-default-worker-preload-data-pv
+  labels:
+    name: graphdb-worker-default-worker-preload-data-pv
+spec:
+  storageClassName: "standard"
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ $.Values.graphdb.workers.persistence.storage }}
+  hostPath:
+    path: {{ $.Values.deployment.storage }}/graphdb-worker-preload-data

--- a/templates/persistence/graphdb-preload-data-pvc.yaml
+++ b/templates/persistence/graphdb-preload-data-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: {{ $.Values.versions.pvc }}
+kind: PersistentVolumeClaim
+metadata:
+  name: graphdb-worker-preload-data-pvc
+  labels:
+    name: graphdb-worker-preload-data-pvc
+spec:
+  volumeName: graphdb-worker-default-worker-preload-data-pv
+  storageClassName: {{ $.Values.graphdb.masters.persistence.storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $.Values.graphdb.masters.persistence.storage }}

--- a/values.yaml
+++ b/values.yaml
@@ -235,7 +235,7 @@ graphdb:
     # (default folder - /data/graphdb-backups).
     # The backups are saved in format MM-DD-YYYY-hh-mm
     # TODO: Add PV options for backups
-    auto_backup: "* 0 * * *"
+    auto_backup: "* * * * *"
     # -- Cleans up the backups directory.
     # Makes sure that there is a limit of the stored backups.
     # Each or both of backups_count and backups_max_age could be used.
@@ -269,11 +269,12 @@ graphdb:
       # -- If trigger is set to true, then the preload tool will be run while initializing the deployment
       # Don't forget to add repo config file(should be named config.ttl) and RDF data file to the graphdb-preload-data-pv
       # (default pv is: /data/graphdb-worker-preload-data)
-      trigger: true
+      trigger: false
       # -- Options to add to the command
       # possible flags: -f, -p, -r
+      # If you use the "-f" option, the tool will override the repository and could lose some data.
       flags: "-f"
-      rdfDataFile: "geonames_europe.ttl "
+      rdfDataFile: "geonames_europe.ttl"
     # -- Tool to preload data in a chosen repo
     # https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-the-loadrdf-tool.html
     loadrdf:
@@ -283,8 +284,9 @@ graphdb:
       trigger: false
       # -- Options to add to the command
       # possible flags: -f, -p
+      # If you use the "-f" option, the tool will override the repository and could lose some data.
       flags: "-f"
-      rdfDataFile: "geonames_europe.ttl "
+      rdfDataFile: "geonames_europe.ttl"
     # -- Tool for scanning and repairing data
     # See https://graphdb.ontotext.com/documentation/enterprise/storage-tool.html
     storage_tool:

--- a/values.yaml
+++ b/values.yaml
@@ -256,6 +256,13 @@ graphdb:
 
   # -- Tools for loading, scanning and repairing data in repos
   tools:
+    resources:
+      limits:
+        cpu: 4
+        memory: "10Gi"
+      requests:
+        cpu: 4
+        memory: "10Gi"
     # -- Tool to preload data in a chosen repo
     # https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-preload.html
     preload:
@@ -282,7 +289,7 @@ graphdb:
     # See https://graphdb.ontotext.com/documentation/enterprise/storage-tool.html
     storage_tool:
       # -- If trigger is set to true, then the storage tool will be run while initializing the deployment
-      trigger: false
+      trigger: true
       # -- commands to run the storage-tool with
       command: "scan"
       # -- repo to run command on

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,8 @@ graphdb:
     # -- Specific GraphDB worker instances configurations. Supported properties for per node configuration are: license, java_args, graphdb_properties
     nodes:
         - name: worker-1
-          license: graphdb-license
+          license: graphdb-worker1-license
+          master: master-1
         - name: worker-2
           java_args: " -Xmx1G -XX:MaxRAMPercentage=70 -XX:+UseContainerSupport"
           nodeSelector: {}
@@ -252,3 +253,39 @@ graphdb:
     # -- The name of the backup directory we want to restore.
     # Must be given in format MM-DD-YY-hh-mm, where MM-DD-YY-hh-mm is your backup directory
     restore_from_backup: "03-31-2021-14-47"
+
+  # -- Tools for loading, scanning and repairing data in repos
+  tools:
+    # -- Tool to preload data in a chosen repo
+    # https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-preload.html
+    preload:
+      # -- If trigger is set to true, then the preload tool will be run while initializing the deployment
+      # Don't forget to add repo config file(should be named config.ttl) and RDF data file to the graphdb-preload-data-pv
+      # (default pv is: /data/graphdb-worker-preload-data)
+      trigger: true
+      # -- Options to add to the command
+      # possible flags: -f, -p, -r
+      flags: "-f"
+      rdfDataFile: "geonames_europe.ttl "
+    # -- Tool to preload data in a chosen repo
+    # https://graphdb.ontotext.com/documentation/enterprise/loading-data-using-the-loadrdf-tool.html
+    loadrdf:
+      # -- If trigger is set to true, then the loadrdf tool will be run while initializing the deployment
+      # Don't forget to add repo config file(should be named config.ttl) and RDF data file to the graphdb-preload-data-pv
+      # (default pv is: /data/graphdb-worker-preload-data)
+      trigger: false
+      # -- Options to add to the command
+      # possible flags: -f, -p
+      flags: "-f"
+      rdfDataFile: "geonames_europe.ttl "
+    # -- Tool for scanning and repairing data
+    # See https://graphdb.ontotext.com/documentation/enterprise/storage-tool.html
+    storage_tool:
+      # -- If trigger is set to true, then the storage tool will be run while initializing the deployment
+      trigger: false
+      # -- commands to run the storage-tool with
+      command: "scan"
+      # -- repo to run command on
+      repository: "repo-test-1"
+      # -- additional options to run the storage-tool with
+      options: ""

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,7 @@ graphdb:
     # -- Specific GraphDB worker instances configurations. Supported properties for per node configuration are: license, java_args, graphdb_properties
     nodes:
         - name: worker-1
-          license: graphdb-worker1-license
+          license: graphdb-license
           master: master-1
         - name: worker-2
           java_args: " -Xmx1G -XX:MaxRAMPercentage=70 -XX:+UseContainerSupport"


### PR DESCRIPTION
Closes [GDB-5620](https://ontotext.atlassian.net/browse/GDB-5620) As a DevOps I want to be able to launch GraphDB’s storage tool/preload tool/loadrdf tool through Helm, before launching GraphDB