### PR TITLE
Add more pod labels

### DIFF
--- a/templates/graphdb-master.yaml
+++ b/templates/graphdb-master.yaml
@@ -11,8 +11,6 @@ metadata:
   name: graphdb-master-{{ $master_index }}
   labels:
     app: graphdb-master-{{ $master_index }}
-    app-release: {{ $.Release.Name }}
-    app-type: master
 spec:
   replicas: 1
   serviceName: graphdb-master-{{ $master_index }}
@@ -46,6 +44,8 @@ spec:
     metadata:
       labels:
         app: graphdb-master-{{ $master_index }}
+        app-release: {{ $.Release.Name }}
+        app-type: master
     spec:
       terminationGracePeriodSeconds: 60
       volumes:

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -12,8 +12,6 @@ metadata:
   name: graphdb-worker-{{ $worker_index }}
   labels:
     app: graphdb-worker-{{ $worker_index }}
-    app-release: {{ $.Release.Name }}
-    app-type: worker
 spec:
   replicas: 1
   serviceName: graphdb-worker-{{ $worker_index }}
@@ -33,6 +31,8 @@ spec:
     metadata:
       labels:
         app: graphdb-worker-{{ $worker_index }}
+        app-release: {{ $.Release.Name }}
+        app-type: worker
     spec:
       terminationGracePeriodSeconds: 60
       volumes:


### PR DESCRIPTION
These labels help to distribute nodes across nodes with `topologySpreadConstraints`. Can be used like this:

```yaml
  masters:
    topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: kubernetes.io/hostname
        whenUnsatisfiable: DoNotSchedule
        labelSelector:
          matchExpressions:
            - key: app-type
              operator: In
              values:
              - master

  workers:
    topologySpreadConstraints:
      - maxSkew: 1
        topologyKey: kubernetes.io/hostname
        whenUnsatisfiable: DoNotSchedule
        labelSelector:
          matchExpressions:
            - key: app-type
              operator: In
              values:
              - worker
```