### PR TITLE
[bugfix]: fix restore-standalone volumeMount error

### DIFF
--- a/templates/graphdb-master.yaml
+++ b/templates/graphdb-master.yaml
@@ -226,7 +226,11 @@ spec:
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           volumeMounts:
+            {{- if hasKey $.Values.graphdb.masters.persistence "volumeClaimTemplateSpec" }}
+            - name: graphdb-master-{{ $master_index }}-data-dynamic-pvc
+            {{- else }}
             - name: graphdb-master-storage
+            {{- end }}
               mountPath: /opt/graphdb/
             - name: graphdb-backup-pvc
               mountPath: {{ $.Values.deployment.storage }}/graphdb-backups/


### PR DESCRIPTION
This should fix a bug when using volumeClaimTemplate. 
We were getting that error:

> Create Pod graphdb-master-1-0 in StatefulSet graphdb-master-1 failed error: Pod "graphdb-master-1-0" is invalid: spec.initContainers[3].volumeMounts[0].name: Not found: "graphdb-master-storage"