### PR TITLE
update ingress template to properly handle root context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 values_overrides.yaml
 values_overrides.yml
+.idea/

--- a/templates/configuration/graphdb-node-configmap.yaml
+++ b/templates/configuration/graphdb-node-configmap.yaml
@@ -11,6 +11,7 @@ data:
     -Dentity-pool-implementation=transactional
     -Dhealth.max.query.time.seconds=60
     -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.append.request.id.headers=true
     -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
     -Dgraphdb.home=/opt/graphdb/home

--- a/templates/gateway/ingress.yaml
+++ b/templates/gateway/ingress.yaml
@@ -15,7 +15,11 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ .Values.deployment.ingress.timeout.connect | quote }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: {{ .Values.deployment.ingress.timeout.read | quote }}
     nginx.ingress.kubernetes.io/proxy-send-timeout: {{ .Values.deployment.ingress.timeout.send | quote }}
+    {{- if eq $.Values.graphdb.workbench.subpath "/" }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
     nginx.ingress.kubernetes.io/x-forwarded-prefix: {{ $.Values.graphdb.workbench.subpath | quote }}
     {{- with .Values.deployment.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
@@ -31,7 +35,11 @@ spec:
     - host: {{ include "resolveDeploymentHost" . | quote }}
       http:
         paths:
+          {{- if eq $.Values.graphdb.workbench.subpath "/" }}
+          - path: /(.*)
+          {{- else }}
           - path: {{ $.Values.graphdb.workbench.subpath }}(/|$)(.*)
+          {{- end }}
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
When `graphdb.workbench.subpath` is set to `/`, the ingress definition doesn't corectly handle the path. Specifically, the regex in the ingress path needs to be different when the path is /. E.g. only glob what's behind the slash and use match group $1 in rewrite target annotation.

Also, `graphdb.external-url` seems to be required when deploying single instance.

GDB-7691