### PR TITLE
Make the service type of graphdb-cluster-proxy optional

### DIFF
--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -60,7 +60,7 @@ metadata:
     app: graphdb-cluster-proxy
     {{- include "graphdb.labels" . | nindent 4 }}
 spec:
-  type: LoadBalancer
+  type: {{ $.Values.graphdb.clusterProxy.serviceType }}
   selector:
     app: graphdb-cluster-proxy
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -125,6 +125,9 @@ graphdb:
     replicas: 1
     # -- Java arguments with which the cluster proxy instances will be launched. GraphDB configuration properties can also be passed here in the format -Dprop=value
     java_args: "-XX:MaxRAMPercentage=70 -Ddefault.min.distinct.threshold=100m -XX:+UseContainerSupport"
+    # -- Service type used by the graphdb-cluster-proxy service
+    # Note: If using ALB in AWS EKS this will default to being on the public internet
+    serviceType: LoadBalancer
     # Node scheduling options such as nodeSelector, affinity, tolerations, topologySpreadConstraints can be set here for ALL nodes.
     # By default, no restrictions are applied.
     # nodeSelector: {}


### PR DESCRIPTION
Current behaviour to to set the service type for graphdb-cluster-proxy to LoadBalancer. In AWS EKS with ALB installed this defaults to the public internet. Currently there is no way to safely deploy this helm chart in AWS EKS with ALB.

Change:
* Default values preserves current behaviour
* Possible to set the type to ClusterIP in the values override for secure deployment in AWS.