### PR TITLE
OTKG-110: Added the ability to further customize the deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+# Idea
+.idea
+*.iml
+
+# Eclipse
+.metadata
+.classpath
+.project
+.settings
+
+# Helm
 values_overrides.yaml
 values_overrides.yml

--- a/templates/graphdb-master.yaml
+++ b/templates/graphdb-master.yaml
@@ -68,6 +68,9 @@ spec:
           configMap:
             name: {{ $.Values.deployment.logbackConfigMap }}
         {{- end }}
+        {{- with .Values.graphdb.masters.extraVolumes }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
+        {{- end }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       nodeSelector:
@@ -88,6 +91,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-master-{{ $master_index }}-configmap
+            {{- with .Values.graphdb.masters.extraEnvFrom }}
+              {{- tpl ( toYaml . ) $ | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.masters.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-master-{{ $master_index }}-data-dynamic-pvc
@@ -102,6 +108,9 @@ spec:
             {{- if and $.Values.graphdb.import_directory_mount.enabled (eq $master_index 1) }}
             - name: graphdb-server-import-dir
               mountPath: /opt/graphdb/home/graphdb-import
+            {{- end }}
+            {{- with .Values.graphdb.masters.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           resources: {{ $.Values.graphdb.masters.resources | toYaml | nindent 12 }}
           # Allow for GraphDB to start within 10*30 seconds before readiness & liveness probes interfere

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -61,6 +61,9 @@ spec:
           persistentVolumeClaim:
             claimName: graphdb-worker-preload-data-pvc
         {{- end }}
+        {{- with .Values.graphdb.workers.extraVolumes }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
+        {{- end }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       nodeSelector:
@@ -81,6 +84,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-worker-{{ $worker_index }}-configmap
+            {{- with .Values.graphdb.workers.extraEnvFrom }}
+              {{- tpl ( toYaml . ) $ | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.workers.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-worker-{{ $worker_index }}-data-dynamic-pvc
@@ -88,6 +94,9 @@ spec:
             - name: graphdb-worker-storage
             {{- end }}
               mountPath: /opt/graphdb/home
+            {{- with .Values.graphdb.workers.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources: {{ $.Values.graphdb.workers.resources | toYaml | nindent 12 }}
           # Allow for GraphDB to start within 10*30 seconds before readiness & liveness probes interfere
           startupProbe:

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,12 @@ graphdb:
              storage: "5Gi"
     # additional JMX attributes to be set after the cluster is initialized
     additionalJmxArrtibutes: {}
+    # additional environment variables to be set for each master
+    extraEnvFrom: []
+    # additional volumes to be set for each master
+    extraVolumes: []
+    # additional volume mounts to be set for each master node pod
+    extraVolumeMounts: []
   workers:
     # -- Reference to a configuration map containing one or more .ttl files used for repository
     # initialization in the post install hook. For reference see https://graphdb.ontotext.com/documentation/standard/configuring-a-repository.html
@@ -248,6 +254,12 @@ graphdb:
         memory: 2Gi
       requests:
         memory: 2Gi
+    # additional environment variables to be set for each worker node
+    extraEnvFrom: []
+    # additional volumes to be set for each worker node
+    extraVolumes: []
+    # additional volume mounts to be set for each worker node pod
+    extraVolumeMounts: []
   # Reference to a configuration map with GraphDB specific configurations.
   # Injected as environment variables.
   #configmap: graphdb-configmap


### PR DESCRIPTION
Updated both masters and workers to render additional configurations:

- Added `extraEnvFrom` applicable for all replicas
- Added `extraVolumes` and `extraVolumeMounts` applicable for all replicas

The new options will allow the provision of custom JARs in GraphDB.

Added gitignore