### PR TITLE
OTKG-110: Fixed the template rendering for extra configurations

### DIFF
--- a/templates/graphdb-master.yaml
+++ b/templates/graphdb-master.yaml
@@ -68,7 +68,7 @@ spec:
           configMap:
             name: {{ $.Values.deployment.logbackConfigMap }}
         {{- end }}
-        {{- with .Values.graphdb.masters.extraVolumes }}
+        {{- with $.Values.graphdb.masters.extraVolumes }}
           {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
       imagePullSecrets:
@@ -91,7 +91,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-master-{{ $master_index }}-configmap
-            {{- with .Values.graphdb.masters.extraEnvFrom }}
+            {{- with $.Values.graphdb.masters.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
           volumeMounts:
@@ -109,7 +109,7 @@ spec:
             - name: graphdb-server-import-dir
               mountPath: /opt/graphdb/home/graphdb-import
             {{- end }}
-            {{- with .Values.graphdb.masters.extraVolumeMounts }}
+            {{- with $.Values.graphdb.masters.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources: {{ $.Values.graphdb.masters.resources | toYaml | nindent 12 }}

--- a/templates/graphdb-worker.yaml
+++ b/templates/graphdb-worker.yaml
@@ -61,7 +61,7 @@ spec:
           persistentVolumeClaim:
             claimName: graphdb-worker-preload-data-pvc
         {{- end }}
-        {{- with .Values.graphdb.workers.extraVolumes }}
+        {{- with $.Values.graphdb.workers.extraVolumes }}
           {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
       imagePullSecrets:
@@ -84,7 +84,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-worker-{{ $worker_index }}-configmap
-            {{- with .Values.graphdb.workers.extraEnvFrom }}
+            {{- with $.Values.graphdb.workers.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
           volumeMounts:
@@ -94,7 +94,7 @@ spec:
             - name: graphdb-worker-storage
             {{- end }}
               mountPath: /opt/graphdb/home
-            {{- with .Values.graphdb.workers.extraVolumeMounts }}
+            {{- with $.Values.graphdb.workers.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources: {{ $.Values.graphdb.workers.resources | toYaml | nindent 12 }}


### PR DESCRIPTION
Updated the templates to use the global context (`$`) when rendering extra volumes, mounts and envFrom.