### PR TITLE
Fixed an issue with cluster proxy connecting to nodes when protocol is set to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # GraphDB Helm chart release notes
+## Version 10.1.5-R2
+### New
+- Fixed an issue with the external proxy connecting to the nodes when https is used
+
 ## Version 10.1.2-R2
 ### New 
 - Added ability to override cluster proxy's type, default remains LoadBalancer

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: Helm chart for GraphDB
 type: application
-version: 10.1.5
+version: 10.1.5-R2
 appVersion: 10.1.5
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png

--- a/templates/configuration/graphdb-cluster-proxy-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-proxy-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   # >- means replace new line with space and no new lines at the end
   GDB_JAVA_OPTS: >-
-    -Dgraphdb.proxy.hosts={{- range $i, $node_index := until ( (int $.Values.graphdb.clusterConfig.nodesCount) )}}{{ $.Values.deployment.protocol }}://graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7200{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},{{- end }}
+    -Dgraphdb.proxy.hosts={{- range $i, $node_index := until ( (int $.Values.graphdb.clusterConfig.nodesCount) )}}http://graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7200{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},{{- end }}
     {{- end }}
     -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}


### PR DESCRIPTION
Changed protocol that the cluster proxy adds the nodes to always be http
Prepared chart for 10.1.5-R2 release