### PR TITLE
Various improvements to the chart gdb 7987 7985 7984 7978 and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Idea
+.idea
+*.iml
+
+# Eclipse
+.metadata
+.classpath
+.project
+.settings
+
+# Helm
 values_overrides.yaml
-values_overrides.yml
-.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # GraphDB Helm chart release notes
+## Version 10.2.0-TR2 (change version before official release)
+### New
+
+- Added configurable security context for both the node and cluster-proxy statefulsets and all the jobs
+- Added extraEnv, extraVolumes and extraVolumeMounts to the statefulsets
+- Added an optional PV/PVC to the cluster-proxy to properly preserve logs (enabled by default)
+- Changed the provision user credentials to be used through a secret instead of rendering inside the jobs
+- Changed the logback.xml and graphdb.properties provisioning to work even if such are already present
+- Changed the graphdb-cluster-config-configmap map to not render when there is no cluster
+- Changed the default values of nodeSelector, affinity, tolerations and topologySpreadConstraints to be a part of the values.yaml file instead of inside the statefulsets
+- Updated default clusterConfig.electionMinTimeout and clusterConfig.electionRangeTimeout to the current GraphDB defaults
+
+## Version 10.2.0-R2
+### New
+- Added the ability to provision a repository 
+
 ## Version 10.1.5-R2
 ### New
 - Fixed an issue with the external proxy connecting to the nodes when https is used

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Helm charts for GraphDB
 
+You can download the GraphDB Helm chart, including all sub-charts managed by Ontotext, from the [Ontotext Helm repository](https://maven.ontotext.com/repository/helm-public/).
+
 ## Install
 ### Prerequisites
 

--- a/files/scripts/graphdb.sh
+++ b/files/scripts/graphdb.sh
@@ -2,10 +2,10 @@
 set -eu
 
 function createCluster {
-  waitAllNodes $1 $3
+  waitAllNodes $1
   local configLocation=$2
-  local authToken=$3
-  local timeout=$4
+  local authToken=$PROVISION_USER_AUTH_TOKEN
+  local timeout=$3
   echo "Creating cluster"
   curl -o response.json -isSL -m $timeout -X POST --header "Authorization: Basic ${authToken}" --header 'Content-Type: application/json' --header 'Accept: */*' -d @"$configLocation" http://graphdb-node-0.graphdb-node:7200/rest/cluster/config
   if grep -q 'HTTP/1.1 201' "response.json"; then
@@ -22,7 +22,7 @@ function createCluster {
 
 function waitService {
   local address=$1
-  local authToken=$2
+  local authToken=$PROVISION_USER_AUTH_TOKEN
 
   local attempt_counter=0
   local max_attempts=100
@@ -42,20 +42,19 @@ function waitService {
 
 function waitAllNodes {
   local node_count=$1
-  local authToken=$2
 
   for (( c=$node_count; c>0; c ))
   do
     c=$((c-1))
     local node_address=http://graphdb-node-$c.graphdb-node:7200
-    waitService "${node_address}/rest/repositories" "$authToken"
+    waitService "${node_address}/rest/repositories"
   done
 }
 
 function createRepositoryFromFile {
-  waitAllNodes $1 $3
+  waitAllNodes $1
   local repositoriesConfigsLocation=$2
-  local authToken=$3
+  local authToken=$PROVISION_USER_AUTH_TOKEN
   local timeout=60
   echo "Creating repositories"
   local success=true

--- a/templates/configuration/graphdb-cluster-config-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-config-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
 # Default configuration map for provisioning the GraphDB cluster configuration.
 # To change it, prepare another configuration map and update "graphdb.configs.clusterConfig"
 apiVersion: {{ .Values.versions.configmap }}
@@ -9,3 +10,4 @@ metadata:
 data:
   cluster-config.json: |-
 {{ tpl (.Files.Get "files/config/cluster-config.json" | indent 4) . }}
+{{- end }}

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -15,6 +15,13 @@ spec:
   selector:
     matchLabels:
       app: graphdb-cluster-proxy
+  volumeClaimTemplates:
+    {{- if $.Values.graphdb.clusterProxy.persistence.enablePersistence }}
+    - metadata:
+        name: graphdb-cluster-proxy-data-dynamic-pvc
+      {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.clusterProxy.persistence.volumeClaimTemplateSpec }}
+      spec: {{ include "renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
+    {{- end }}
   template:
     metadata:
       labels:
@@ -57,6 +64,10 @@ spec:
             - name: gdb-proxy-rpc
               containerPort: 7300
           volumeMounts:
+            {{- if $.Values.graphdb.clusterProxy.persistence.enablePersistence }}
+            - name: graphdb-cluster-proxy-data-dynamic-pvc
+              mountPath: /opt/graphdb/home
+            {{- end }}
             {{- with $.Values.graphdb.clusterProxy.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -31,10 +31,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 15
       setHostnameAsFQDN: true
+      {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
       volumes:
-        {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
-          {{- tpl ( toYaml . ) $ | nindent 8 }}
-        {{- end }}
+        {{- tpl ( toYaml . ) $ | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{- $.Values.graphdb.clusterProxy.nodeSelector | toYaml | nindent 8 }}
       affinity:
@@ -44,7 +44,7 @@ spec:
       topologySpreadConstraints:
         {{- $.Values.graphdb.clusterProxy.topologySpreadConstraints | toYaml | nindent 8 }}
       securityContext:
-        {{- $.Values.graphdb.clusterProxy.securityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.clusterProxy.podSecurityContext | toYaml | nindent 8 }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       containers:
@@ -72,7 +72,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources: {{ $.Values.graphdb.clusterProxy.resources | toYaml | nindent 12 }}
-          securityContext: {{ $.Values.graphdb.clusterProxy.containerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.clusterProxy.securityContext | toYaml | nindent 12 }}
           startupProbe: {{ $.Values.graphdb.clusterProxy.startupProbe | toYaml | nindent 12 }}
           readinessProbe: {{ $.Values.graphdb.clusterProxy.readinessProbe | toYaml | nindent 12 }}
           livenessProbe: {{ $.Values.graphdb.clusterProxy.livenessProbe | toYaml | nindent 12 }}

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -24,14 +24,20 @@ spec:
     spec:
       terminationGracePeriodSeconds: 15
       setHostnameAsFQDN: true
+      volumes:
+        {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
+        {{- end }}
       nodeSelector:
-        {{- default "{}" ($.Values.graphdb.clusterProxy.nodeSelector | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.clusterProxy.nodeSelector | toYaml | nindent 8 }}
       affinity:
-        {{- default "{}" ($.Values.graphdb.clusterProxy.affinity | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.clusterProxy.affinity | toYaml | nindent 8 }}
       tolerations:
-        {{- default "{}" ($.Values.graphdb.clusterProxy.tolerations | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.clusterProxy.tolerations | toYaml | nindent 8 }}
       topologySpreadConstraints:
-        {{- default "{}" ($.Values.graphdb.clusterProxy.topologySpreadConstraints | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.clusterProxy.topologySpreadConstraints | toYaml | nindent 8 }}
+      securityContext:
+        {{- $.Values.graphdb.clusterProxy.securityContext | toYaml | nindent 8 }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       containers:
@@ -42,12 +48,20 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-cluster-proxy-configmap
+            {{- with $.Values.graphdb.clusterProxy.extraEnvFrom }}
+              {{- tpl ( toYaml . ) $ | nindent 12 }}
+            {{- end }}
           ports:
             - name: gdb-proxy-port
               containerPort: 7200
             - name: gdb-proxy-rpc
               containerPort: 7300
+          volumeMounts:
+            {{- with $.Values.graphdb.clusterProxy.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources: {{ $.Values.graphdb.clusterProxy.resources | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.clusterProxy.containerSecurityContext | toYaml | nindent 12 }}
           startupProbe: {{ $.Values.graphdb.clusterProxy.startupProbe | toYaml | nindent 12 }}
           readinessProbe: {{ $.Values.graphdb.clusterProxy.readinessProbe | toYaml | nindent 12 }}
           livenessProbe: {{ $.Values.graphdb.clusterProxy.livenessProbe | toYaml | nindent 12 }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -79,7 +79,7 @@ spec:
       topologySpreadConstraints:
         {{- $.Values.graphdb.node.topologySpreadConstraints | toYaml | nindent 8 }}
       securityContext:
-        {{- $.Values.graphdb.node.securityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.node.podSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: graphdb-node
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
@@ -112,7 +112,7 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           resources: {{ $.Values.graphdb.node.resources | toYaml | nindent 12 }}
-          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.node.securityContext | toYaml | nindent 12 }}
           # Allow for GraphDB to start within 10*30 seconds before readiness & liveness probes interfere
           startupProbe: {{ $.Values.graphdb.node.startupProbe | toYaml | nindent 12 }}
           readinessProbe: {{ $.Values.graphdb.node.readinessProbe | toYaml | nindent 12 }}
@@ -132,7 +132,7 @@ spec:
               mountPath: /opt/graphdb/home
             - name: graphdb-license
               mountPath: /tmp/license/
-          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.node.initContainerSecurityContext | toYaml | nindent 12 }}
           command: ['sh', '-c']
           args:
             - |
@@ -175,7 +175,7 @@ spec:
             - name: graphdb-logback-config
               mountPath: /tmp/graphdb-logback-configmap
             {{- end }}
-          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.node.initContainerSecurityContext | toYaml | nindent 12 }}
           command: ['sh', '-c']
           args:
             - |

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -65,16 +65,21 @@ spec:
           configMap:
             name: {{ $configs.logbackConfigMap }}
         {{- end }}
+        {{- with $.Values.graphdb.node.extraVolumes }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
+        {{- end }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       nodeSelector:
-        {{- default "{}" ($.Values.graphdb.node.nodeSelector | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.node.nodeSelector | toYaml | nindent 8 }}
       affinity:
-        {{- default "{}" ($.Values.graphdb.node.affinity | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.node.affinity | toYaml | nindent 8 }}
       tolerations:
-        {{- default "{}" ($.Values.graphdb.node.tolerations | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.node.tolerations | toYaml | nindent 8 }}
       topologySpreadConstraints:
-        {{- default "{}" ($.Values.graphdb.node.topologySpreadConstraints | toYaml | nindent 8) }}
+        {{- $.Values.graphdb.node.topologySpreadConstraints | toYaml | nindent 8 }}
+      securityContext:
+        {{- $.Values.graphdb.node.securityContext | toYaml | nindent 8 }}
       containers:
         - name: graphdb-node
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
@@ -89,6 +94,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: graphdb-node-configmap
+            {{- with $.Values.graphdb.node.extraEnvFrom }}
+              {{- tpl ( toYaml . ) $ | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-node-data-dynamic-pvc
@@ -100,7 +108,11 @@ spec:
             - name: graphdb-server-import-dir
               mountPath: /opt/graphdb/home/graphdb-import
             {{- end }}
+            {{- with $.Values.graphdb.node.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources: {{ $.Values.graphdb.node.resources | toYaml | nindent 12 }}
+          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
           # Allow for GraphDB to start within 10*30 seconds before readiness & liveness probes interfere
           startupProbe: {{ $.Values.graphdb.node.startupProbe | toYaml | nindent 12 }}
           readinessProbe: {{ $.Values.graphdb.node.readinessProbe | toYaml | nindent 12 }}
@@ -120,6 +132,7 @@ spec:
               mountPath: /opt/graphdb/home
             - name: graphdb-license
               mountPath: /tmp/license/
+          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
           command: ['sh', '-c']
           args:
             - |
@@ -162,6 +175,7 @@ spec:
             - name: graphdb-logback-config
               mountPath: /tmp/graphdb-logback-configmap
             {{- end }}
+          securityContext: {{ $.Values.graphdb.node.containerSecurityContext | toYaml | nindent 12 }}
           command: ['sh', '-c']
           args:
             - |
@@ -176,12 +190,12 @@ spec:
                 mkdir -p /opt/graphdb/home/data ;
                 cp /tmp/graphdb-settings-configmap/settings.js /opt/graphdb/home/data/settings.js
               fi
-              if [[ ! -f /opt/graphdb/home/conf/graphdb.properties && -f /tmp/graphdb-properties-configmap/graphdb.properties ]]; then
+              if [[ -f /tmp/graphdb-properties-configmap/graphdb.properties ]]; then
                 echo "Provisioning graphdb properties file..."
                 mkdir -p /opt/graphdb/home/conf ;
                 cp /tmp/graphdb-properties-configmap/graphdb.properties /opt/graphdb/home/conf/graphdb.properties
               fi
-              if [[ ! -f /opt/graphdb/home/conf/logback.xml && -f /tmp/graphdb-logback-configmap/logback.xml ]]; then
+              if [[ -f /tmp/graphdb-logback-configmap/logback.xml ]]; then
                 echo "Provisioning logging config file..."
                 mkdir -p /opt/graphdb/home/conf ;
                 cp /tmp/graphdb-logback-configmap/logback.xml /opt/graphdb/home/conf/logback.xml

--- a/templates/graphdb-provision-user-secret.yaml
+++ b/templates/graphdb-provision-user-secret.yaml
@@ -1,0 +1,16 @@
+# Secret used from the jobs to authenticate to running GraphDB instances
+apiVersion: {{ .Values.versions.secret }}
+kind: Secret
+metadata:
+  name: graphdb-provision-user
+  labels:
+    {{- include "graphdb.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback, post-install, post-upgrade, post-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+    "helm.sh/hook-weight": "-9"
+type: Opaque
+data:
+  provisioningUsername: {{ .Values.graphdb.security.provisioningUsername | b64enc | quote }}
+  provisioningPassword: {{ .Values.graphdb.security.provisioningPassword | b64enc | quote }}
+  PROVISION_USER_AUTH_TOKEN: {{ printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc | b64enc | quote }}

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -1,5 +1,4 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-{{- $authToken := printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc }}
 apiVersion: {{ $.Values.versions.job }}
 kind: Job
 metadata:
@@ -16,12 +15,15 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+      securityContext:
+        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: patch-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          envFrom:
+            - secretRef:
+                name: graphdb-provision-user
+          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils
@@ -32,7 +34,7 @@ spec:
             - |
               cp /tmp/cluster-config/cluster-config.json /usr/local/bin/cluster-config.json
               cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh patchCluster "/usr/local/bin/cluster-config.json" "{{ $authToken }}" >> /proc/1/fd/1
+              /usr/local/bin/update-cluster.sh patchCluster "/usr/local/bin/cluster-config.json" >> /proc/1/fd/1
       restartPolicy: Never
       volumes:
         - name: cluster-config

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: patch-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: patch-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: create-graphdb-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: create-graphdb-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -1,6 +1,4 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-#Set auth token var
-{{- $authToken := printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc }}
 apiVersion: {{ $.Values.versions.job }}
 kind: Job
 metadata:
@@ -17,12 +15,15 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+      securityContext:
+        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: create-graphdb-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          envFrom:
+            - secretRef:
+                name: graphdb-provision-user
+          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils
@@ -33,7 +34,7 @@ spec:
             - |
               cp /tmp/cluster-config/cluster-config.json /usr/local/bin/cluster-config.json
               cp /tmp/utils/graphdb.sh /usr/local/bin/graphdb.sh; chmod +x /usr/local/bin/graphdb.sh
-              /usr/local/bin/graphdb.sh createCluster {{ .Values.graphdb.clusterConfig.nodesCount }} "/usr/local/bin/cluster-config.json" "{{ $authToken }}" {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
+              /usr/local/bin/graphdb.sh createCluster {{ .Values.graphdb.clusterConfig.nodesCount }} "/usr/local/bin/cluster-config.json" {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
       restartPolicy: Never
       volumes:
         - name: cluster-config

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -17,14 +17,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: provision-repositories
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -1,7 +1,5 @@
 {{- $configs := (.Values.graphdb.configs | default dict) }}
 {{- if $configs.provisionRepositoriesConfigMap }}
-#Set auth token var
-{{- $authToken := printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc }}
 apiVersion: {{ $.Values.versions.job }}
 kind: Job
 metadata:
@@ -18,12 +16,15 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+      securityContext:
+        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: provision-repositories
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          envFrom:
+            - secretRef:
+                name: graphdb-provision-user
+          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils
@@ -33,7 +34,7 @@ spec:
           args:
             - |
               cp /tmp/utils/graphdb.sh /usr/local/bin/graphdb.sh; chmod +x /usr/local/bin/graphdb.sh
-              /usr/local/bin/graphdb.sh createRepositoryFromFile {{ .Values.graphdb.clusterConfig.nodesCount }} "/tmp/repositories-config" "{{ $authToken }}" >> /proc/1/fd/1
+              /usr/local/bin/graphdb.sh createRepositoryFromFile {{ .Values.graphdb.clusterConfig.nodesCount }} "/tmp/repositories-config" >> /proc/1/fd/1
       restartPolicy: Never
       volumes:
         - name: repositories-config

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -17,14 +17,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: provision-repositories
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -1,4 +1,3 @@
-{{- $authToken := printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc }}
 apiVersion: {{ $.Values.versions.job }}
 kind: Job
 metadata:
@@ -14,12 +13,15 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+      securityContext:
+        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-down-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          envFrom:
+            - secretRef:
+                name: graphdb-provision-user
+          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils
@@ -27,7 +29,7 @@ spec:
           args:
             - |
               cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh removeNodes {{ .Values.graphdb.clusterConfig.nodesCount }} "{{ $authToken }}" {{ $.Release.Namespace }} >> /proc/1/fd/1
+              /usr/local/bin/update-cluster.sh removeNodes {{ .Values.graphdb.clusterConfig.nodesCount }} {{ $.Release.Namespace }} >> /proc/1/fd/1
       restartPolicy: Never
       volumes:
         - name: graphdb-utils

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -14,14 +14,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-down-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -14,14 +14,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-down-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-up-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -1,5 +1,4 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-{{- $authToken := printf "%s:%s" .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | b64enc }}
 apiVersion: {{ $.Values.versions.job }}
 kind: Job
 metadata:
@@ -16,12 +15,15 @@ spec:
     spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+      securityContext:
+        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-up-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
+          envFrom:
+            - secretRef:
+                name: graphdb-provision-user
+          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils
@@ -29,7 +31,7 @@ spec:
           args:
             - |
               cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh addNodes {{ .Values.graphdb.clusterConfig.nodesCount }} "{{ $authToken }}" {{ $.Release.Namespace }} {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
+              /usr/local/bin/update-cluster.sh addNodes {{ .Values.graphdb.clusterConfig.nodesCount }} {{ $.Release.Namespace }} {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
       restartPolicy: Never
       volumes:
         - name: graphdb-utils

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -16,14 +16,14 @@ spec:
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
-        {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 8 }}
+        {{- $.Values.deployment.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-up-cluster
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user
-          securityContext: {{- $.Values.deployment.jobContainerSecurityContext | toYaml | nindent 12 }}
+          securityContext: {{- $.Values.deployment.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: graphdb-utils
               mountPath: /tmp/utils

--- a/values.yaml
+++ b/values.yaml
@@ -218,6 +218,18 @@ graphdb:
       requests:
         memory: 1500Mi
         cpu: 800m
+    # -- Persistence configurations.
+    # By default, Helm will use a PV that reads and writes to the host file system.
+    persistence:
+      # enable or disable proxy persistence
+      enablePersistence: false
+      # use dynamic volume provisioning
+      volumeClaimTemplateSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "500Mi"
     # -- Configurations for the GraphDB cluster proxy startup probe. Misconfigured probe can lead to a failing cluster.
     startupProbe:
       httpGet:

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,7 @@ graphdb:
     extraVolumeMounts: []
     # securityContext defines privilege and access control settings for the node pods.
     securityContext: {}
-    # securityContext defines privilege and access control settings for the node containers (including provisioning ones).
+    # containerSecurityContext defines privilege and access control settings for the node containers (including provisioning ones).
     containerSecurityContext: {}
 
   # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
@@ -222,7 +222,7 @@ graphdb:
     # By default, Helm will use a PV that reads and writes to the host file system.
     persistence:
       # enable or disable proxy persistence
-      enablePersistence: false
+      enablePersistence: true
       # use dynamic volume provisioning
       volumeClaimTemplateSpec:
         accessModes:
@@ -254,15 +254,15 @@ graphdb:
       initialDelaySeconds: 120
       timeoutSeconds: 5
       periodSeconds: 10
-    # additional environment variables to be set for each worker node
+    # additional environment variables to be set for each cluster proxy
     extraEnvFrom: []
-    # additional volumes to be set for each worker node
+    # additional volumes to be set for each cluster proxy
     extraVolumes: []
-    # additional volume mounts to be set for each worker node pod
+    # additional volume mounts to be set for each cluster proxy
     extraVolumeMounts: []
     # securityContext defines privilege and access control settings for the proxy pods.
     securityContext: {}
-    # securityContext defines privilege and access control settings for the proxy containers.
+    # containerSecurityContext defines privilege and access control settings for the proxy containers.
     containerSecurityContext: {}
 
   # GraphDB workbench configurations

--- a/values.yaml
+++ b/values.yaml
@@ -75,12 +75,6 @@ deployment:
       connect: 5
       read: 600
       send: 600
-  # jobSecurityContext defines privilege and access control settings for all the job pods
-  jobPodSecurityContext: {}
-  # jobContainerSecurityContext defines privilege and access control settings for all the job containers
-  jobSecurityContext:
-    allowPrivilegeEscalation: false
-    runAsUser: 0
 
 # GraphDB database configurations
 graphdb:
@@ -126,7 +120,12 @@ graphdb:
     # bcrypt encrypted password. default: iHaveSuperpowers
     provisioningPassword: iHaveSuperpowers
 
+  # jobSecurityContext defines privilege and access control settings for all the job pods
+  jobPodSecurityContext: {}
+  # jobContainerSecurityContext defines privilege and access control settings for all the job containers
+  jobSecurityContext: {}
   # -- Settings for the GraphDB cluster nodes
+
   node:
     # -- Reference to a secret containing 'graphdb.license' file to be used by the nodes.
     # Important: Must be created beforehand

--- a/values.yaml
+++ b/values.yaml
@@ -124,8 +124,8 @@ graphdb:
   jobPodSecurityContext: {}
   # jobContainerSecurityContext defines privilege and access control settings for all the job containers
   jobSecurityContext: {}
-  # -- Settings for the GraphDB cluster nodes
 
+  # -- Settings for the GraphDB cluster nodes
   node:
     # -- Reference to a secret containing 'graphdb.license' file to be used by the nodes.
     # Important: Must be created beforehand

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,12 @@ deployment:
       connect: 5
       read: 600
       send: 600
+  # jobSecurityContext defines privilege and access control settings for all the job pods
+  jobSecurityContext: {}
+  # jobContainerSecurityContext defines privilege and access control settings for all the job containers
+  jobContainerSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsUser: 0
 
 # GraphDB database configurations
 graphdb:
@@ -89,9 +95,9 @@ graphdb:
     clusterCreationTimeout: 60
     # -- Cluster configuration parameters:
     # The minimum wait time in milliseconds for a heartbeat from a leader.
-    electionMinTimeout: 7000
+    electionMinTimeout: 8000
     # The variable portion of each waiting period in milliseconds for a heartbeat.
-    electionRangeTimeout: 5000
+    electionRangeTimeout: 6000
     # The interval in milliseconds between each heartbeat that is sent to follower nodes by the leader.
     heartbeatInterval: 2000
     #The size of the data blocks transferred during data replication streaming through the RPC protocol.

--- a/values.yaml
+++ b/values.yaml
@@ -50,7 +50,7 @@ deployment:
   # Needed to configure ingress as well as some components require it to properly render their UIs
   protocol: http
   # Important: This should be a resolvable hostname, not an IP address!
-  host: localhost
+  host: graphdb.local
 
   # Configures SSL termination on ingress level.
   # See https://kubernetes.github.io/ingress-nginx/examples/tls-termination/
@@ -81,7 +81,7 @@ graphdb:
   clusterConfig:
     # -- Number of GraphDB nodes to be used in the cluster.
     # Set value to 1 to run a standalone GraphDB instance.
-    nodesCount: 1
+    nodesCount: 3
     # -- A secret used for secure communication amongst the nodes in the cluster.
     clusterSecret: s3cr37
     # -- Timeout for the cluster creation CURL query.
@@ -118,55 +118,6 @@ graphdb:
     # bcrypt encrypted password. default: iHaveSuperpowers
     provisioningPassword: iHaveSuperpowers
 
-  # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
-  # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed
-  clusterProxy:
-    # -- Number of cluster proxies used to access the GraphDB cluster
-    replicas: 1
-    # -- Java arguments with which the cluster proxy instances will be launched. GraphDB configuration properties can also be passed here in the format -Dprop=value
-    java_args: "-XX:MaxRAMPercentage=70 -Ddefault.min.distinct.threshold=100m -XX:+UseContainerSupport"
-    # -- Service type used by the graphdb-cluster-proxy service
-    # Note: If using ALB in AWS EKS this will default to being on the public internet
-    serviceType: LoadBalancer
-    # Node scheduling options such as nodeSelector, affinity, tolerations, topologySpreadConstraints can be set here for ALL nodes.
-    # By default, no restrictions are applied.
-    # nodeSelector: {}
-    # affinity: {}
-    # tolerations: {}
-    # topologySpreadConstraints: {}
-    # -- Minimum requirements for a successfully running GraphDB cluster proxy
-    resources:
-      limits:
-        memory: 1Gi
-        cpu: 500m
-      requests:
-        memory: 1Gi
-        cpu: 500m
-    # -- Configurations for the GraphDB cluster proxy startup probe. Misconfigured probe can lead to a failing cluster.
-    startupProbe:
-      httpGet:
-        path: /protocol
-        port: gdb-proxy-port
-      failureThreshold: 30
-      timeoutSeconds: 5
-      periodSeconds: 10
-    # -- Configurations for the GraphDB cluster proxy readiness probe. Misconfigured probe can lead to a failing cluster.
-    readinessProbe:
-      httpGet:
-        path: /proxy/ready
-        port: gdb-proxy-port
-      initialDelaySeconds: 20
-      timeoutSeconds: 5
-      periodSeconds: 10
-    # -- Configurations for the GraphDB cluster proxy liveness probe. Misconfigured probe can lead to a failing cluster.
-    livenessProbe:
-      httpGet:
-        path: /proxy/health
-        port: gdb-proxy-port
-      initialDelaySeconds: 60
-      timeoutSeconds: 5
-      periodSeconds: 10
-
   # -- Settings for the GraphDB cluster nodes
   node:
     # -- Reference to a secret containing 'graphdb.license' file to be used by the nodes.
@@ -176,10 +127,10 @@ graphdb:
     java_args: "-XX:MaxRAMPercentage=70 -Ddefault.min.distinct.threshold=100m -XX:+UseContainerSupport"
     # Node scheduling options such as nodeSelector, affinity, tolerations, topologySpreadConstraints can be set here for ALL nodes.
     # By default, no restrictions are applied.
-    # nodeSelector: {}
-    # affinity: {}
-    # tolerations: {}
-    # topologySpreadConstraints: {}
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
     # -- Persistence configurations.
     # By default, Helm will use a PV that reads and writes to the host file system.
     persistence:
@@ -224,6 +175,75 @@ graphdb:
       initialDelaySeconds: 60
       timeoutSeconds: 5
       periodSeconds: 10
+    # additional environment variables to be set for the graphdb nodes
+    extraEnvFrom: []
+    # additional volumes to be set for the graphdb nodes
+    extraVolumes: []
+    # additional volume mounts to be set for the graphdb nodes
+    extraVolumeMounts: []
+    # securityContext defines privilege and access control settings for the node pods.
+    securityContext: {}
+    # securityContext defines privilege and access control settings for the node containers (including provisioning ones).
+    containerSecurityContext: {}
+
+  # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
+  # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed
+  clusterProxy:
+    # -- Number of cluster proxies used to access the GraphDB cluster
+    replicas: 1
+    # -- Java arguments with which the cluster proxy instances will be launched. GraphDB configuration properties can also be passed here in the format -Dprop=value
+    java_args: "-XX:MaxRAMPercentage=70 -Ddefault.min.distinct.threshold=100m -XX:+UseContainerSupport"
+    # -- Service type used by the graphdb-cluster-proxy service
+    # Note: If using ALB in AWS EKS this will default to being on the public internet
+    serviceType: LoadBalancer
+    # Node scheduling options such as nodeSelector, affinity, tolerations, topologySpreadConstraints can be set here for ALL nodes.
+    # By default, no restrictions are applied.
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    # -- Minimum requirements for a successfully running GraphDB cluster proxy
+    resources:
+      limits:
+        memory: 1Gi
+        cpu: 500m
+      requests:
+        memory: 1Gi
+        cpu: 500m
+    # -- Configurations for the GraphDB cluster proxy startup probe. Misconfigured probe can lead to a failing cluster.
+    startupProbe:
+      httpGet:
+        path: /protocol
+        port: gdb-proxy-port
+      failureThreshold: 30
+      timeoutSeconds: 5
+      periodSeconds: 10
+    # -- Configurations for the GraphDB cluster proxy readiness probe. Misconfigured probe can lead to a failing cluster.
+    readinessProbe:
+      httpGet:
+        path: /proxy/ready
+        port: gdb-proxy-port
+      initialDelaySeconds: 20
+      timeoutSeconds: 5
+      periodSeconds: 10
+    # -- Configurations for the GraphDB cluster proxy liveness probe. Misconfigured probe can lead to a failing cluster.
+    livenessProbe:
+      httpGet:
+        path: /proxy/health
+        port: gdb-proxy-port
+      initialDelaySeconds: 60
+      timeoutSeconds: 5
+      periodSeconds: 10
+    # additional environment variables to be set for each worker node
+    extraEnvFrom: []
+    # additional volumes to be set for each worker node
+    extraVolumes: []
+    # additional volume mounts to be set for each worker node pod
+    extraVolumeMounts: []
+    # securityContext defines privilege and access control settings for the proxy pods.
+    securityContext: {}
+    # securityContext defines privilege and access control settings for the proxy containers.
+    containerSecurityContext: {}
 
   # GraphDB workbench configurations
   workbench:

--- a/values.yaml
+++ b/values.yaml
@@ -76,9 +76,9 @@ deployment:
       read: 600
       send: 600
   # jobSecurityContext defines privilege and access control settings for all the job pods
-  jobSecurityContext: {}
+  jobPodSecurityContext: {}
   # jobContainerSecurityContext defines privilege and access control settings for all the job containers
-  jobContainerSecurityContext:
+  jobSecurityContext:
     allowPrivilegeEscalation: false
     runAsUser: 0
 
@@ -189,10 +189,12 @@ graphdb:
     extraVolumes: []
     # additional volume mounts to be set for the graphdb nodes
     extraVolumeMounts: []
-    # securityContext defines privilege and access control settings for the node pods.
+    # podSecurityContext defines privilege and access control settings for the node pods.
+    podSecurityContext: {}
+    # securityContext defines privilege and access control settings for the node container running graphdb.
     securityContext: {}
-    # containerSecurityContext defines privilege and access control settings for the node containers (including provisioning ones).
-    containerSecurityContext: {}
+    # provisionSecurityContext defines privilege and access control settings for the node containers provisioning configurations for graphdb.
+    initContainerSecurityContext: {}
 
   # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
   # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed
@@ -260,10 +262,10 @@ graphdb:
     extraVolumes: []
     # additional volume mounts to be set for each cluster proxy
     extraVolumeMounts: []
-    # securityContext defines privilege and access control settings for the proxy pods.
+    # podSecurityContext defines privilege and access control settings for the proxy pods.
+    podSecurityContext: {}
+    # securityContext defines privilege and access control settings for the proxy containers.
     securityContext: {}
-    # containerSecurityContext defines privilege and access control settings for the proxy containers.
-    containerSecurityContext: {}
 
   # GraphDB workbench configurations
   workbench:


### PR DESCRIPTION
Added .gitignore
Added security context to pods and containers of the statefulsets
Added jobSecurityContext and jobContainerSecurityContext
Added extraEnv, extraVolumes and extraVolumeMounts to the statefulsets
Added Ontotext's Helm repository to README
Added an optional PV/PVC for the proxy to properly preserve logs when someone has readonly by default 
Changed graphdb.properties and logback.xml provisioning to overwrite any previously set such files
Fixed graphdb-cluster-config-configmap.yaml to not render when there isn't a cluster
Moved the default values of nodeSelector, affinity, tolerations and topologySpreadConstraints from the statefulsets to the values.yaml
Moved the provision user credentials to its own secret so the job's don't render an authentication token
Updated default clusterConfig.electionMinTimeout and clusterConfig.electionRangeTimeout to the current GraphDB defaults
