### PR TITLE
DEVSUP-28: GraphDB on OpenShift

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Custom
+examples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # GraphDB Helm chart release notes
+
 ## Version 10.2.0-TR2 (change version before official release)
+
 ### New
 
 - Added configurable security context for both the node and cluster-proxy statefulsets and all the jobs
@@ -8,33 +10,45 @@
 - Changed the provision user credentials to be used through a secret instead of rendering inside the jobs
 - Changed the logback.xml and graphdb.properties provisioning to work even if such are already present
 - Changed the graphdb-cluster-config-configmap map to not render when there is no cluster
-- Changed the default values of nodeSelector, affinity, tolerations and topologySpreadConstraints to be a part of the values.yaml file instead of inside the statefulsets
+- Changed the default values of nodeSelector, affinity, tolerations and topologySpreadConstraints to be a part of the values.yaml file
+  instead of inside the statefulsets
 - Updated default clusterConfig.electionMinTimeout and clusterConfig.electionRangeTimeout to the current GraphDB defaults
+- Updated the cluster proxy probes settings, so it can become available sooner
 
 ## Version 10.2.0-R2
+
 ### New
-- Added the ability to provision a repository 
+
+- Added the ability to provision a repository
 
 ## Version 10.1.5-R2
+
 ### New
+
 - Fixed an issue with the external proxy connecting to the nodes when https is used
 
 ## Version 10.1.2-R2
-### New 
+
+### New
+
 - Added ability to override cluster proxy's type, default remains LoadBalancer
 
-## Version 10.1.1-R2 
+## Version 10.1.1-R2
 
-### New 
+### New
+
 - Fixed ingress template to properly handle root context
 - Fixed single node returning wrong location header with explicit transactions
 
 ## Version 10.0.1
 
 ### Breaking
-- The graphdb-node service now is always headless. If you installed Version 10.0.0 with `graphdb.clusterConfig.nodesCount` set to `1` you will have to delete the service prior to an update
+
+- The graphdb-node service now is always headless. If you installed Version 10.0.0 with `graphdb.clusterConfig.nodesCount` set to `1` you
+  will have to delete the service prior to an update
 
 ### New
+
 - Upgrade to GraphDB 10.0.1
 - Cluster size can now be scaled
 - Fixed an issue with deploying with security turned on
@@ -43,10 +57,12 @@
 ## Version 10.0.0
 
 ### Breaking
-New major release that isn't compatible with the old chart, due to major breaking changes in Graphdb 10.
-Migration steps can be found [here](README.md#cluster-migration-from-graphdb-9x-to-100).
+
+New major release that isn't compatible with the old chart, due to major breaking changes in Graphdb 10. Migration steps can be found
+[here](README.md#cluster-migration-from-graphdb-9x-to-100).
 
 ### New
+
 - Changed to work with the new GraphDB 10.
 - Removed Kong.
 - Moved from multiple stateful sets with 1 replica to statefulsets with multiple replicas.
@@ -62,7 +78,8 @@ Migration steps can be found [here](README.md#cluster-migration-from-graphdb-9x-
 
 ### New
 
-- Added global variables support (global.deployment.host/global.ingressHost, global.storageClass, global.imagePullSecrets and global.imageRegistry)
+- Added global variables support (global.deployment.host/global.ingressHost, global.storageClass, global.imagePullSecrets and
+  global.imageRegistry)
 - Add ability to override logback.xml by setting `deplyment.logbackConfigFile` to the location of the file to use
 - Set additional JMX attributes using `graphdb.masters.additionalJmxArrtibutes`. This is a map of attr_name=attr_value pairs
 - Fixed loadrdf tool path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   instead of inside the statefulsets
 - Updated default clusterConfig.electionMinTimeout and clusterConfig.electionRangeTimeout to the current GraphDB defaults
 - Updated the cluster proxy probes settings, so it can become available sooner
+- Updated the cluster and repositories jobs with simpler arguments removing the need to copy scripts and to make them executable
+- Added ephemeral volumes in the cluster and repositories jobs to avoid issues with readonly file systems
 
 ## Version 10.2.0-R2
 

--- a/examples/openshift-local/README.md
+++ b/examples/openshift-local/README.md
@@ -1,0 +1,51 @@
+# GraphDB Cluster in OpenShift
+
+Example configurations for deploying GraphDB cluster in [OpenShift Local](https://developers.redhat.com/products/openshift-local/overview).
+
+The primary purpose is to show an example of the necessary OpenShift local overrides and the proper `securityContext` configurations so 
+GraphDB can be deployed without policy violations.
+
+Read more about Kubernetes security context and OpenShift security context constraints:
+
+- https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+- https://docs.openshift.com/container-platform/4.12/security/container_security/security-hosts-vms.html
+
+## Usage
+
+1. Create an OpenShift local instance
+
+Follow the official [documentation](https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.15/html/getting_started_guide/installation_gsg)
+
+Make sure you give the instance enough memory and CPU to be able to deploy the cluster. 
+Or you can lower the memory and CPU requests/limits.
+
+2. Create dedicated namespace
+
+```bash
+kubectl create namespace graphdb
+```
+
+3. To be able to deploy and use GraphDB in cluster mode, you have to create a secret with GraphDB license.
+
+```bash
+kubectl --namespace graphdb create secret generic graphdb-license --from-file graphdb.license=/path/to/graphdb.license
+```
+
+4. Deploy GraphDB
+
+```bash
+helm upgrade --install  --namespace graphdb --values values.yaml graphdb-openshift ../../
+```
+
+This will deploy a GraphDB cluster of 3 replicas along with a single GraphDB cluster proxy. 
+Instances are configured for being accessed at [https://graphdb.apps-crc.testing](https://graphdb.apps-crc.testing).
+
+5. Open a route to GraphDB's workbench
+
+You'll have to use the `oc` utility provided by `crc` (from step 1):
+
+```bash
+oc create route edge --service=graphdb-cluster-proxy --port=7200 --hostname=graphdb.apps-crc.testing --namespace graphdb
+```
+
+You can now access GraphDB at [https://graphdb.apps-crc.testing/](https://graphdb.apps-crc.testing/).

--- a/examples/openshift-local/values.yaml
+++ b/examples/openshift-local/values.yaml
@@ -1,0 +1,74 @@
+global:
+  storageClass: "crc-csi-hostpath-provisioner"
+
+deployment:
+  host: graphdb.apps-crc.testing
+  protocol: https
+  ingress:
+    enabled: false
+
+graphdb:
+  clusterConfig:
+    nodesCount: 3
+
+  workbench:
+    subpath: /
+
+  node:
+    # Cluster requires license, you have to provision it before deploying this chart
+    license: graphdb-license
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+    # Uncomment to disable default resource limits and requests
+    #resources:
+    #  limits:
+    #    memory: null
+    #    cpu: null
+    #  requests:
+    #    memory: null
+    #    cpu: null
+    initContainerSecurityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+
+  clusterProxy:
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop:
+          - ALL
+    # Uncomment to disable default resource limits and requests
+    #resources:
+    #  limits:
+    #    memory: null
+    #    cpu: null
+    #  requests:
+    #    memory: null
+    #    cpu: null
+
+  jobSecurityContext:
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -11,8 +11,10 @@ metadata:
     "helm.sh/hook-weight": "2"
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 4
   template:
     spec:
+      restartPolicy: Never
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
@@ -25,23 +27,25 @@ spec:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
+            - name: job-temp
+              mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
             - name: cluster-config
               mountPath: /tmp/cluster-config
-          command: ['sh','-c']
+          command: ['bash']
           args:
-            - |
-              cp /tmp/cluster-config/cluster-config.json /usr/local/bin/cluster-config.json
-              cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh patchCluster "/usr/local/bin/cluster-config.json" >> /proc/1/fd/1
-      restartPolicy: Never
+            - "/tmp/utils/update-cluster.sh"
+            - "patchCluster"
+            - "/tmp/cluster-config/cluster-config.json"
       volumes:
+        - name: job-temp
+          emptyDir:
+            sizeLimit: 10Mi
         - name: cluster-config
           configMap:
             name: graphdb-cluster-config-configmap
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
-  backoffLimit: 4
 {{- end }}

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -11,8 +11,10 @@ metadata:
     "helm.sh/hook-weight": "-1"
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 9
   template:
     spec:
+      restartPolicy: Never
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
@@ -25,23 +27,27 @@ spec:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
+            - name: job-temp
+              mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
             - name: cluster-config
               mountPath: /tmp/cluster-config
-          command: ['sh','-c']
+          command: ['bash']
           args:
-            - |
-              cp /tmp/cluster-config/cluster-config.json /usr/local/bin/cluster-config.json
-              cp /tmp/utils/graphdb.sh /usr/local/bin/graphdb.sh; chmod +x /usr/local/bin/graphdb.sh
-              /usr/local/bin/graphdb.sh createCluster {{ .Values.graphdb.clusterConfig.nodesCount }} "/usr/local/bin/cluster-config.json" {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
-      restartPolicy: Never
+            - "/tmp/utils/graphdb.sh"
+            - createCluster
+            - "{{ .Values.graphdb.clusterConfig.nodesCount }}"
+            - "/tmp/cluster-config/cluster-config.json"
+            - "{{ .Values.graphdb.clusterConfig.clusterCreationTimeout }}"
       volumes:
+        - name: job-temp
+          emptyDir:
+            sizeLimit: 10Mi
         - name: cluster-config
           configMap:
             name: graphdb-cluster-config-configmap
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
-  backoffLimit: 9
 {{- end }}

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -12,8 +12,10 @@ metadata:
     "helm.sh/hook-weight": "4"
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 3
   template:
     spec:
+      restartPolicy: Never
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
@@ -26,22 +28,26 @@ spec:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
+            - name: job-temp
+              mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
             - name: repositories-config
               mountPath: /tmp/repositories-config
-          command: ['sh','-c']
+          command: ['bash']
           args:
-            - |
-              cp /tmp/utils/graphdb.sh /usr/local/bin/graphdb.sh; chmod +x /usr/local/bin/graphdb.sh
-              /usr/local/bin/graphdb.sh createRepositoryFromFile {{ .Values.graphdb.clusterConfig.nodesCount }} "/tmp/repositories-config" >> /proc/1/fd/1
-      restartPolicy: Never
+            - "/tmp/utils/graphdb.sh"
+            - "createRepositoryFromFile"
+            - "{{ .Values.graphdb.clusterConfig.nodesCount }}"
+            - "/tmp/repositories-config"
       volumes:
+        - name: job-temp
+          emptyDir:
+            sizeLimit: 10Mi
         - name: repositories-config
           configMap:
             name: {{ .Values.graphdb.configs.provisionRepositoriesConfigMap }}
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
-  backoffLimit: 3
 {{- end }}

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -9,8 +9,10 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 4
   template:
     spec:
+      restartPolicy: Never
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
@@ -23,17 +25,20 @@ spec:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
+            - name: job-temp
+              mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
-          command: ['sh','-c']
+          command: ['bash']
           args:
-            - |
-              cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh removeNodes {{ .Values.graphdb.clusterConfig.nodesCount }} {{ $.Release.Namespace }} >> /proc/1/fd/1
-      restartPolicy: Never
+            - "/tmp/utils/update-cluster.sh"
+            - "removeNodes"
+            - "{{ .Values.graphdb.clusterConfig.nodesCount }}"
+            - "{{ $.Release.Namespace }}"
       volumes:
+        - name: job-temp
+          emptyDir:
+            sizeLimit: 10Mi
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
-  backoffLimit: 4
-

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -11,8 +11,10 @@ metadata:
     "helm.sh/hook-weight": "1"
 spec:
   ttlSecondsAfterFinished: 300
+  backoffLimit: 4
   template:
     spec:
+      restartPolicy: Never
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
@@ -25,17 +27,22 @@ spec:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
+            - name: job-temp
+              mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
-          command: ['sh','-c']
+          command: ['bash']
           args:
-            - |
-              cp /tmp/utils/update-cluster.sh /usr/local/bin/update-cluster.sh; chmod +x /usr/local/bin/update-cluster.sh
-              /usr/local/bin/update-cluster.sh addNodes {{ .Values.graphdb.clusterConfig.nodesCount }} {{ $.Release.Namespace }} {{ .Values.graphdb.clusterConfig.clusterCreationTimeout }} >> /proc/1/fd/1
-      restartPolicy: Never
+            - "/tmp/utils/update-cluster.sh"
+            - "addNodes"
+            - "{{ .Values.graphdb.clusterConfig.nodesCount }}"
+            - "{{ $.Release.Namespace }}"
+            - "{{ .Values.graphdb.clusterConfig.clusterCreationTimeout }}"
       volumes:
+        - name: job-temp
+          emptyDir:
+            sizeLimit: 10Mi
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap
-  backoffLimit: 4
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -234,17 +234,16 @@ graphdb:
     # -- Configurations for the GraphDB cluster proxy startup probe. Misconfigured probe can lead to a failing cluster.
     startupProbe:
       httpGet:
-        path: /protocol
+        path: /proxy/ready
         port: gdb-proxy-port
-      failureThreshold: 40
-      timeoutSeconds: 5
-      periodSeconds: 10
+      failureThreshold: 60
+      timeoutSeconds: 3
+      periodSeconds: 5
     # -- Configurations for the GraphDB cluster proxy readiness probe. Misconfigured probe can lead to a failing cluster.
     readinessProbe:
       httpGet:
         path: /proxy/ready
         port: gdb-proxy-port
-      initialDelaySeconds: 60
       timeoutSeconds: 5
       periodSeconds: 10
     # -- Configurations for the GraphDB cluster proxy liveness probe. Misconfigured probe can lead to a failing cluster.


### PR DESCRIPTION
**Tuned the cluster proxy probes**

- Switched the startup probe to use `/proxy/ready`
- Increased the startup failureThreshold
- Lowered the startup period to allow faster readiness
- Lowered the readiness initialDelaySeconds to allow faster registration

All of these changes should allow the proxy to become available sooner.

**Updated the Jobs**

- Updated the cluster and repositories jobs with simpler arguments removing
  the need to copy scripts and to make them executable
- Added ephemeral volumes in the cluster and repositories jobs to avoid issues
  with readonly file systems

These changes allow GraphDB to be deployed on more strict Kubernetes clusters.

**Added OpenShift example deployment**

Introduced new directory structure examples/ for various deployment scenarios.

Added values.yaml overrides with configurations allowing for a GraphDB cluster
to be deployed on a OpenShift Local instance. Notable changes:

- Added readme explaining the required steps
- Configured the storageClass to use the `crc` specific one as the default is
`standard`
- Updated the components `securityContext` so the chart can be deployed without
  policy violations by OpenShift.

**Additonal changes**

Formatted the CHANGELOG.md