### PR TITLE
DEVSUP-40: Helm Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Added configurations for changing the `revisionHistoryLimit` for nodes and cluster proxies.
 - Added configurations for adding extra `podLabels` and `podAnnotations` for both the nodes and cluster proxies.
 
+### Improvements
+
+- Updated the templates to avoid rendering empty configurations
+
 ## Version 10.2.1
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 10.2.1-R1
+
+### New
+
+- Added configurations for extra env vars in the nodes and cluster proxies, see `graphdb.node.envFrom` and `graphdb.clusterProxy.extraEnv`.
+
 ## Version 10.2.1
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added configurations for extra env vars in the nodes and cluster proxies, see `graphdb.node.envFrom` and `graphdb.clusterProxy.extraEnv`.
 - Added configurations for changing the `revisionHistoryLimit` for nodes and cluster proxies.
 - Added configurations for adding extra `podLabels` and `podAnnotations` for both the nodes and cluster proxies.
+- Added configurations for `terminationGracePeriodSeconds` to both the nodes and cluster proxies.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New
 
 - Added configurations for extra env vars in the nodes and cluster proxies, see `graphdb.node.envFrom` and `graphdb.clusterProxy.extraEnv`.
+- Added configurations for changing the `revisionHistoryLimit` for nodes and cluster proxies.
 
 ## Version 10.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added configurations for extra env vars in the nodes and cluster proxies, see `graphdb.node.envFrom` and `graphdb.clusterProxy.extraEnv`.
 - Added configurations for changing the `revisionHistoryLimit` for nodes and cluster proxies.
+- Added configurations for adding extra `podLabels` and `podAnnotations` for both the nodes and cluster proxies.
 
 ## Version 10.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Updated the templates to avoid rendering empty configurations
 - Removed unused helper template `graphdbLicenseSecret`
+- Added `graphdb` prefix in the helper templates function naming
 
 ## Version 10.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Improvements
 
 - Updated the templates to avoid rendering empty configurations
+- Removed unused helper template `graphdbLicenseSecret`
 
 ## Version 10.2.1
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -20,4 +20,4 @@ You can check their status with kubectl get pods
 WARNING: You are attempting to make a cluster without providing a license secret!
 {{ end }}
 Endpoints:
-* GraphDB workbench: {{ .Values.deployment.protocol }}://{{ include "resolveDeploymentHost" . }}{{ .Values.graphdb.workbench.subpath }}
+* GraphDB workbench: {{ .Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" . }}{{ .Values.graphdb.workbench.subpath }}

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -1,5 +1,5 @@
 
-{{- define "resolveDeploymentHost" -}}
+{{- define "graphdb.resolveDeploymentHost" -}}
   {{- $global := .Values.global | default dict -}}
   {{- $globalDeployment := $global.deployment | default dict -}}
   {{- print (index $globalDeployment "host" | default (index $global "ingressHost") | default .Values.deployment.host) -}}
@@ -8,7 +8,7 @@
 {{/*
 Combined image pull secrets
 */}}
-{{- define "combinedImagePullSecrets" -}}
+{{- define "graphdb.combinedImagePullSecrets" -}}
   {{- $secrets := list -}}
 
   {{- if .Values.deployment.imagePullSecret -}}
@@ -28,7 +28,7 @@ Rendenders a volumeClaimTemplate as yaml.
 If the storage class name is not specified - 'global.storageClass' is checked and if set it is used as the storageClassName for the template.
 Otherwise it is left blank and cluster default will be used.
 */}}
-{{- define "renderVolumeClaimTemplateSpec" }}
+{{- define "graphdb.renderVolumeClaimTemplateSpec" }}
   {{- if and .globalStorageClassName (not .spec.storageClassName) }}
     {{- $spec := set .spec "storageClassName" .globalStorageClassName }}
     {{- $spec | toYaml }}
@@ -40,7 +40,7 @@ Otherwise it is left blank and cluster default will be used.
 {{/*
 Renders full name of the graphdb pod
 */}}
-{{- define "renderFullImageName" -}}
+{{- define "graphdb.renderFullImageName" -}}
   {{- $fullImageName := .image.repository -}}
 
   {{- if or .globalRegistry .image.registry -}}

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -23,11 +23,6 @@ Combined image pull secrets
   {{- toYaml $secrets -}}
 {{- end -}}
 
-{{- define "graphdbLicenseSecret"}}
-  {{- $secret := (lookup "v1" "Secret" "" "graphdb-license") | default dict }}
-  {{- toYaml $secret}}
-{{- end -}}
-
 {{/*
 Rendenders a volumeClaimTemplate as yaml.
 If the storage class name is not specified - 'global.storageClass' is checked and if set it is used as the storageClassName for the template.

--- a/templates/configuration/graphdb-cluster-proxy-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-proxy-configmap.yaml
@@ -10,8 +10,8 @@ data:
   GDB_JAVA_OPTS: >-
     -Dgraphdb.proxy.hosts={{- range $i, $node_index := until ( (int $.Values.graphdb.clusterConfig.nodesCount) )}}http://graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7200{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},{{- end }}
     {{- end }}
-    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
-    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.auth.token.secret={{ $.Values.graphdb.clusterConfig.clusterSecret | quote }}
     -Dgraphdb.home=/opt/graphdb/home
     {{ default $.Values.graphdb.node.java_args}}

--- a/templates/configuration/graphdb-node-configmap.yaml
+++ b/templates/configuration/graphdb-node-configmap.yaml
@@ -10,7 +10,7 @@ data:
     -Denable-context-index=true
     -Dentity-pool-implementation=transactional
     -Dhealth.max.query.time.seconds=60
-    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.append.request.id.headers=true
     -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
     -Dgraphdb.home=/opt/graphdb/home
@@ -18,6 +18,6 @@ data:
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
     -Dgraphdb.auth.token.secret={{ $.Values.graphdb.clusterConfig.clusterSecret | quote }}
 {{- else }}
-    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
 {{- end }}
     {{ default $.Values.graphdb.node.java_args}}

--- a/templates/gateway/ingress.yaml
+++ b/templates/gateway/ingress.yaml
@@ -28,11 +28,11 @@ spec:
   {{- if .Values.deployment.tls.enabled }}
   tls:
     - hosts:
-        - {{ include "resolveDeploymentHost" . | quote }}
+        - {{ include "graphdb.resolveDeploymentHost" . | quote }}
       secretName: {{ required "TLS secret is required!" .Values.deployment.tls.secretName }}
   {{- end }}
   rules:
-    - host: {{ include "resolveDeploymentHost" . | quote }}
+    - host: {{ include "graphdb.resolveDeploymentHost" . | quote }}
       http:
         paths:
           {{- if eq $.Values.graphdb.workbench.subpath "/" }}

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -58,6 +58,10 @@ spec:
             {{- with $.Values.graphdb.clusterProxy.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
+          {{- with .Values.graphdb.clusterProxy.extraEnv }}
+          env:
+            {{- tpl ( toYaml . ) $ | nindent 12 }}
+          {{- end }}
           ports:
             - name: gdb-proxy-port
               containerPort: 7200

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -39,19 +39,23 @@ spec:
       terminationGracePeriodSeconds: 15
       setHostnameAsFQDN: true
       {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
-      volumes:
-        {{- tpl ( toYaml . ) $ | nindent 8 }}
+      volumes: {{- tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
-      nodeSelector:
-        {{- $.Values.graphdb.clusterProxy.nodeSelector | toYaml | nindent 8 }}
-      affinity:
-        {{- $.Values.graphdb.clusterProxy.affinity | toYaml | nindent 8 }}
-      tolerations:
-        {{- $.Values.graphdb.clusterProxy.tolerations | toYaml | nindent 8 }}
-      topologySpreadConstraints:
-        {{- $.Values.graphdb.clusterProxy.topologySpreadConstraints | toYaml | nindent 8 }}
-      securityContext:
-        {{- $.Values.graphdb.clusterProxy.podSecurityContext | toYaml | nindent 8 }}
+      {{- with .Values.graphdb.clusterProxy.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.clusterProxy.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.clusterProxy.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.clusterProxy.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.clusterProxy.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
       containers:
@@ -66,8 +70,7 @@ spec:
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
           {{- with .Values.graphdb.clusterProxy.extraEnv }}
-          env:
-            {{- tpl ( toYaml . ) $ | nindent 12 }}
+          env: {{- tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           ports:
             - name: gdb-proxy-port
@@ -82,11 +85,21 @@ spec:
             {{- with $.Values.graphdb.clusterProxy.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          resources: {{ $.Values.graphdb.clusterProxy.resources | toYaml | nindent 12 }}
-          securityContext: {{ $.Values.graphdb.clusterProxy.securityContext | toYaml | nindent 12 }}
-          startupProbe: {{ $.Values.graphdb.clusterProxy.startupProbe | toYaml | nindent 12 }}
-          readinessProbe: {{ $.Values.graphdb.clusterProxy.readinessProbe | toYaml | nindent 12 }}
-          livenessProbe: {{ $.Values.graphdb.clusterProxy.livenessProbe | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.clusterProxy.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.clusterProxy.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.clusterProxy.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.clusterProxy.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.clusterProxy.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
 ---
 apiVersion: {{ $.Values.versions.service }}
 kind: Service

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -36,7 +36,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      terminationGracePeriodSeconds: 15
+      terminationGracePeriodSeconds: {{ .Values.graphdb.clusterProxy.terminationGracePeriodSeconds }}
       setHostnameAsFQDN: true
       {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
       volumes: {{- tpl ( toYaml . ) $ | nindent 8 }}

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -12,6 +12,7 @@ spec:
   replicas: {{ $.Values.graphdb.clusterProxy.replicas }}
   serviceName: graphdb-proxy
   podManagementPolicy: Parallel
+  revisionHistoryLimit: {{ .Values.graphdb.clusterProxy.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: graphdb-cluster-proxy

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -27,8 +27,14 @@ spec:
     metadata:
       labels:
         app: graphdb-cluster-proxy
+        {{- with .Values.graphdb.clusterProxy.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configuration/graphdb-cluster-proxy-configmap.yaml") . | sha256sum }}
+        {{- with .Values.graphdb.clusterProxy.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 15
       setHostnameAsFQDN: true

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -21,7 +21,7 @@ spec:
     - metadata:
         name: graphdb-cluster-proxy-data-dynamic-pvc
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.clusterProxy.persistence.volumeClaimTemplateSpec }}
-      spec: {{ include "renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
+      spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
   template:
     metadata:
@@ -57,10 +57,10 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       containers:
         - name: graphdb-proxy
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           command: ["/opt/graphdb/dist/bin/cluster-proxy"]
           envFrom:

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -4,8 +4,9 @@ apiVersion: {{ $.Values.versions.statefulset }}
 kind: StatefulSet
 metadata:
   name: graphdb-node
-  labels: {{- include "graphdb.labels" . | nindent 4 }}
+  labels:
     app: graphdb-node
+    {{- include "graphdb.labels" . | nindent 4 }}
 spec:
   replicas: {{ $.Values.graphdb.clusterConfig.nodesCount }}
   serviceName: graphdb-node
@@ -35,8 +36,14 @@ spec:
     metadata:
       labels:
         app: graphdb-node
+        {{- with .Values.graphdb.node.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configuration/graphdb-node-configmap.yaml") . | sha256sum }}
+        {{- with .Values.graphdb.node.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       setHostnameAsFQDN: true
       terminationGracePeriodSeconds: 120

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -97,6 +97,10 @@ spec:
             {{- with $.Values.graphdb.node.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
+          {{- with .Values.graphdb.node.extraEnv }}
+          env:
+            {{- tpl ( toYaml . ) $ | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-node-data-dynamic-pvc

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -76,18 +76,23 @@ spec:
         {{- with $.Values.graphdb.node.extraVolumes }}
           {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
+      {{- with .Values.graphdb.node.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.node.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.node.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.node.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.graphdb.node.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         {{- include "combinedImagePullSecrets" $ | nindent 8 }}
-      nodeSelector:
-        {{- $.Values.graphdb.node.nodeSelector | toYaml | nindent 8 }}
-      affinity:
-        {{- $.Values.graphdb.node.affinity | toYaml | nindent 8 }}
-      tolerations:
-        {{- $.Values.graphdb.node.tolerations | toYaml | nindent 8 }}
-      topologySpreadConstraints:
-        {{- $.Values.graphdb.node.topologySpreadConstraints | toYaml | nindent 8 }}
-      securityContext:
-        {{- $.Values.graphdb.node.podSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: graphdb-node
           image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
@@ -106,8 +111,7 @@ spec:
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
           {{- with .Values.graphdb.node.extraEnv }}
-          env:
-            {{- tpl ( toYaml . ) $ | nindent 12 }}
+          env: {{- tpl ( toYaml . ) $ | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
@@ -123,12 +127,21 @@ spec:
             {{- with $.Values.graphdb.node.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-          resources: {{ $.Values.graphdb.node.resources | toYaml | nindent 12 }}
-          securityContext: {{ $.Values.graphdb.node.securityContext | toYaml | nindent 12 }}
-          # Allow for GraphDB to start within 10*30 seconds before readiness & liveness probes interfere
-          startupProbe: {{ $.Values.graphdb.node.startupProbe | toYaml | nindent 12 }}
-          readinessProbe: {{ $.Values.graphdb.node.readinessProbe | toYaml | nindent 12 }}
-          livenessProbe: {{ $.Values.graphdb.node.livenessProbe | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.node.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.readinessProbe }}
+          readinessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.livenessProbe }}
+          livenessProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
       initContainers:
       {{- if $.Values.graphdb.node.license }}
         # LICENSE PROVISION
@@ -144,7 +157,9 @@ spec:
               mountPath: /opt/graphdb/home
             - name: graphdb-license
               mountPath: /tmp/license/
-          securityContext: {{ $.Values.graphdb.node.initContainerSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.node.initContainerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ['sh', '-c']
           args:
             - |
@@ -187,7 +202,9 @@ spec:
             - name: graphdb-logback-config
               mountPath: /tmp/graphdb-logback-configmap
             {{- end }}
-          securityContext: {{ $.Values.graphdb.node.initContainerSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.node.initContainerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ['sh', '-c']
           args:
             - |
@@ -232,9 +249,9 @@ spec:
       port: 7200
       targetPort: 7200
       protocol: TCP
-{{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
+    {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
     - name: rpc
       port: 7300
       targetPort: 7300
       protocol: TCP
-{{- end }}
+    {{- end }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -23,13 +23,13 @@ spec:
     - metadata:
         name: graphdb-node-data-dynamic-pvc
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.node.persistence.volumeClaimTemplateSpec }}
-      spec: {{ include "renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
+      spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
     {{- if $.Values.graphdb.import_directory_mount.enabled }}
     - metadata:
         name: graphdb-server-import-dir
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.import_directory_mount.volumeClaimTemplateSpec }}
-      spec: {{ include "renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
+      spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
   {{- end }}
   template:
@@ -92,10 +92,10 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       containers:
         - name: graphdb-node
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           ports:
             - name: graphdb
@@ -146,7 +146,7 @@ spec:
       {{- if $.Values.graphdb.node.license }}
         # LICENSE PROVISION
         - name: provision-license
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
@@ -177,7 +177,7 @@ spec:
         {{- end }}
         # PROVISION SETTINGS AND SECURITY
         - name: provision-settings
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -46,7 +46,7 @@ spec:
         {{- end }}
     spec:
       setHostnameAsFQDN: true
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: {{ .Values.graphdb.node.terminationGracePeriodSeconds }}
       volumes:
         {{- if $.Values.graphdb.node.license }}
         - name: graphdb-license

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -12,6 +12,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
+  revisionHistoryLimit: {{ .Values.graphdb.node.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: graphdb-node

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       restartPolicy: Never
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
         {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: patch-cluster
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       restartPolicy: Never
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
         {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: create-graphdb-cluster
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -17,12 +17,12 @@ spec:
     spec:
       restartPolicy: Never
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
         {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: provision-repositories
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -14,12 +14,12 @@ spec:
     spec:
       restartPolicy: Never
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
         {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-down-cluster
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       restartPolicy: Never
       imagePullSecrets:
-        {{- include "combinedImagePullSecrets" $ | nindent 8 }}
+        {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       securityContext:
         {{- $.Values.graphdb.jobPodSecurityContext | toYaml | nindent 8 }}
       containers:
         - name: scale-up-cluster
-          image: {{ include "renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
+          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           envFrom:
             - secretRef:
                 name: graphdb-provision-user

--- a/values.yaml
+++ b/values.yaml
@@ -184,6 +184,8 @@ graphdb:
       periodSeconds: 10
     # additional environment variables to be set for the graphdb nodes
     extraEnvFrom: []
+    # additional environment variables to be set for the graphdb nodes
+    extraEnv: []
     # additional volumes to be set for the graphdb nodes
     extraVolumes: []
     # additional volume mounts to be set for the graphdb nodes
@@ -256,6 +258,8 @@ graphdb:
       periodSeconds: 10
     # additional environment variables to be set for each cluster proxy
     extraEnvFrom: []
+    # additional environment variables to be set for each cluster proxy
+    extraEnv: []
     # additional volumes to be set for each cluster proxy
     extraVolumes: []
     # additional volume mounts to be set for each cluster proxy

--- a/values.yaml
+++ b/values.yaml
@@ -204,6 +204,8 @@ graphdb:
     initContainerSecurityContext: {}
     # changes the maximum amount of kept revisions
     revisionHistoryLimit: 10
+    # grace period in seconds before terminating the pods
+    terminationGracePeriodSeconds: 120
 
   # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
   # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed
@@ -281,6 +283,8 @@ graphdb:
     securityContext: {}
     # changes the maximum amount of kept revisions
     revisionHistoryLimit: 10
+    # grace period in seconds before terminating the pods
+    terminationGracePeriodSeconds: 30
 
   # GraphDB workbench configurations
   workbench:

--- a/values.yaml
+++ b/values.yaml
@@ -196,6 +196,8 @@ graphdb:
     securityContext: {}
     # provisionSecurityContext defines privilege and access control settings for the node containers provisioning configurations for graphdb.
     initContainerSecurityContext: {}
+    # changes the maximum amount of kept revisions
+    revisionHistoryLimit: 10
 
   # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
   # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed
@@ -268,6 +270,8 @@ graphdb:
     podSecurityContext: {}
     # securityContext defines privilege and access control settings for the proxy containers.
     securityContext: {}
+    # changes the maximum amount of kept revisions
+    revisionHistoryLimit: 10
 
   # GraphDB workbench configurations
   workbench:

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,9 @@ images:
     repository: busybox
     tag: "1.31"
 
+# Extra labels for the deployed resources
+extraLabels: {}
+
 ####### DEPLOYMENT CONFIGURATIONS #######
 deployment:
   # -- Defines the policy with which components will request their image.
@@ -138,6 +141,9 @@ graphdb:
     affinity: {}
     tolerations: []
     topologySpreadConstraints: []
+    # Extra pod labels and annotations
+    podLabels: {}
+    podAnnotations: {}
     # -- Persistence configurations.
     # By default, Helm will use a PV that reads and writes to the host file system.
     persistence:
@@ -215,6 +221,9 @@ graphdb:
     affinity: {}
     tolerations: []
     topologySpreadConstraints: []
+    # Extra pod labels and annotations
+    podLabels: {}
+    podAnnotations: {}
     # -- Minimum requirements for a successfully running GraphDB cluster proxy
     resources:
       limits:


### PR DESCRIPTION
Changes:

- GDB-8218: Added extra environment variables: Added extraEnv configurations for both the GraphDB nodes and cluster proxies.
- GDB-8219: Configure revision history: Added `revisionHistoryLimit` configurations for nodes and cluster proxies.
- GDB-8217: Configure extra pod labels and annotations: Added configurations for adding extra `podLabels` and `podAnnotations` for
- both the nodes and cluster proxies.
- GDB-7985: Skip rendering empty configurations
- GDB-8219: Configure termination grace period: Added configurations for `terminationGracePeriodSeconds` to both the nodes and cluster proxies.
- GDB-7985: Removed unused helper template
- GDB-7993: Updated helper templates naming: Added `graphdb` prefix in the helper templates function naming