### PR TITLE
GDB-8277 fix users.js config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New
 
+- Added function for the provisioner to be extracted from the `values.yaml`. 
 - Added configurations for extra env vars in the nodes and cluster proxies, see `graphdb.node.envFrom` and `graphdb.clusterProxy.extraEnv`.
 - Added configurations for changing the `revisionHistoryLimit` for nodes and cluster proxies.
 - Added configurations for adding extra `podLabels` and `podAnnotations` for both the nodes and cluster proxies.

--- a/files/config/users.js
+++ b/files/config/users.js
@@ -13,7 +13,7 @@
       },
       "dateCreated" : 1618403171751
     },
-    "provisioner" : {
+    "{{ .Values.graphdb.security.provisioningUsername }}" : {
       "username" : "{{ .Values.graphdb.security.provisioningUsername }}",
       "password" : "{bcrypt}{{ htpasswd .Values.graphdb.security.provisioningUsername .Values.graphdb.security.provisioningPassword | trimPrefix (printf "%s:" .Values.graphdb.security.provisioningUsername) }}",
       "grantedAuthorities" : [ "ROLE_ADMIN" ],


### PR DESCRIPTION
Currently the provisioner was hard coded and not extracted from the values.yaml and if we changed it there we end up with an error.