### PR TITLE
GDB-8287: Helm improvements for extendability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New
 
 - Added configurations for overriding graphdb-node's command and arguments, see `graphdb.node.command` and `graphdb.node.args`
+- Added configurations for Pod Disruption Budget for the GraphDB nodes, see `graphdb.pdb`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Removed `versions` field as it is not really used nor needed
+- Removed the license provisioning init container in favor of directly mounting the license
 
 ## Version 10.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 10.2.3
+
+### Changed
+
+- Removed `versions` field as it is not really used nor needed
+
 ## Version 10.2.2
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Removed `versions` field as it is not really used nor needed
 - Removed the license provisioning init container in favor of directly mounting the license
+- Removed unused `graphdb-node-storage` volume mount
 
 ## Version 10.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 10.2.3
 
+### New
+
+- Added configurations for overriding graphdb-node's command and arguments, see `graphdb.node.command` and `graphdb.node.args`
+
 ### Changed
 
 - Removed `versions` field as it is not really used nor needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed `versions` field as it is not really used nor needed
 - Removed the license provisioning init container in favor of directly mounting the license
 - Removed unused `graphdb-node-storage` volume mount
+- Updated the resources to not set CPU limits in order to avoid CPU throttling, lowered the default CPU requirements
 
 ## Version 10.2.2
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,14 +1,22 @@
 #
-# Helm chart for GraphDB
+# Official Helm chart for GraphDB
 #
 apiVersion: v2
 name: graphdb
-description: Helm chart for GraphDB
+description: GraphDB is an enterprise ready Semantic Graph Database
 type: application
 version: 10.2.2
 appVersion: 10.2.2
+kubeVersion: ^1.22.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png
 maintainers:
   - name: Ontotext GraphDB team
     email: graphdb-support@ontotext.com
+sources:
+  - https://github.com/Ontotext-AD/graphdb-helm
+keywords:
+  - ontotext
+  - graphdb
+  - semantic
+  - database

--- a/templates/configuration/graphdb-cluster-config-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-config-configmap.yaml
@@ -1,7 +1,7 @@
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
 # Default configuration map for provisioning the GraphDB cluster configuration.
 # To change it, prepare another configuration map and update "graphdb.configs.clusterConfig"
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-cluster-config-configmap

--- a/templates/configuration/graphdb-cluster-proxy-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-proxy-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
-apiVersion: {{ $.Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-cluster-proxy-configmap

--- a/templates/configuration/graphdb-logback-configmap.yaml
+++ b/templates/configuration/graphdb-logback-configmap.yaml
@@ -3,7 +3,7 @@
 {{- if eq $configs.logbackConfigMap "graphdb-logback-configmap" }}
 # Default configuration map for provisioning GraphDB logback settings.
 # To change it, prepare another configuration map and update "graphdb.configs.logbackConfigMap"
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-logback-configmap

--- a/templates/configuration/graphdb-node-configmap.yaml
+++ b/templates/configuration/graphdb-node-configmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ $.Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-node-configmap

--- a/templates/configuration/graphdb-properties-configmap.yaml
+++ b/templates/configuration/graphdb-properties-configmap.yaml
@@ -3,7 +3,7 @@
 {{- if eq $configs.propertiesConfigMap "graphdb-properties-configmap" }}
 # Default configuration map for provisioning GraphDB properties.
 # To change it, prepare another configuration map and update "graphdb.configs.propertiesConfigMap"
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-properties-configmap

--- a/templates/configuration/graphdb-settings-configmap.yaml
+++ b/templates/configuration/graphdb-settings-configmap.yaml
@@ -3,7 +3,7 @@
 {{- if or (eq $settingsConfigMap "graphdb-settings-configmap") (and (not $settingsConfigMap ) (.Values.graphdb.security.enabled)) }}
 # Default configuration map for provisioning GraphDB settings.js file.
 # To change it, prepare another configuration map and update "graphdb.configs.settingsConfigMap"
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-settings-configmap

--- a/templates/configuration/graphdb-users-configmap.yaml
+++ b/templates/configuration/graphdb-users-configmap.yaml
@@ -3,7 +3,7 @@
 {{- if or (eq $usersConfigMap "graphdb-users-configmap") (and (not $usersConfigMap) (.Values.graphdb.security.enabled)) }}
 # Default configuration map for provisioning GraphDB users.js file.
 # To change it, prepare another configuration map and update "graphdb.configs.usersConfigMap"
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-users-configmap

--- a/templates/gateway/ingress.yaml
+++ b/templates/gateway/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.deployment.ingress.enabled }}
----
-apiVersion: {{ .Values.versions.ingress }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -1,7 +1,7 @@
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
 {{- $configs := ($.Values.graphdb.configs | default dict) }}
 ---
-apiVersion: {{ $.Values.versions.statefulset }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: gdb-proxy
@@ -101,7 +101,7 @@ spec:
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}
 ---
-apiVersion: {{ $.Values.versions.service }}
+apiVersion: v1
 kind: Service
 metadata:
   name: graphdb-cluster-proxy
@@ -118,7 +118,7 @@ spec:
       targetPort: 7200
       protocol: TCP
 ---
-apiVersion: {{ $.Values.versions.service }}
+apiVersion: v1
 kind: Service
 metadata:
   name: graphdb-proxy

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -122,8 +122,6 @@ spec:
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-node-data-dynamic-pvc
-            {{- else }}
-            - name: graphdb-node-storage
             {{- end }}
               mountPath: /opt/graphdb/home
             {{- if $.Values.graphdb.node.license }}
@@ -161,8 +159,6 @@ spec:
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
             - name: graphdb-node-data-dynamic-pvc
-            {{- else }}
-            - name: graphdb-node-storage
             {{- end }}
               mountPath: /opt/graphdb/home
             {{- if or $configs.settingsConfigMap $.Values.graphdb.security.enabled }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -120,6 +120,11 @@ spec:
             - name: graphdb-node-storage
             {{- end }}
               mountPath: /opt/graphdb/home
+            {{- if $.Values.graphdb.node.license }}
+            - name: graphdb-license
+              mountPath: /opt/graphdb/home/conf/graphdb.license
+              subPath: graphdb.license
+            {{- end }}
             {{- if $.Values.graphdb.import_directory_mount.enabled }}
             - name: graphdb-server-import-dir
               mountPath: /opt/graphdb/home/graphdb-import
@@ -143,38 +148,6 @@ spec:
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}
       initContainers:
-      {{- if $.Values.graphdb.node.license }}
-        # LICENSE PROVISION
-        - name: provision-license
-          image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}
-          imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
-          volumeMounts:
-            {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
-            - name: graphdb-node-data-dynamic-pvc
-            {{- else }}
-            - name: graphdb-node-storage
-            {{- end }}
-              mountPath: /opt/graphdb/home
-            - name: graphdb-license
-              mountPath: /tmp/license/
-          {{- with .Values.graphdb.node.initContainerSecurityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
-          {{- end }}
-          command: ['sh', '-c']
-          args:
-            - |
-              mkdir -p /opt/graphdb/home/conf/
-              cd /opt/graphdb/home/conf/
-              [ -f graphdb.license ] && rm graphdb.license
-
-              mkdir -p /opt/graphdb/home/work/
-              cd /opt/graphdb/home/work/
-              [ -f graphdb.license ] && rm graphdb.license
-
-              echo 'Provisioning GraphDB node license'
-              cp /tmp/license/*.license ./graphdb.license
-              echo 'Done'
-        {{- end }}
         # PROVISION SETTINGS AND SECURITY
         - name: provision-settings
           image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.busybox) }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -1,6 +1,6 @@
 {{- $configs := ($.Values.graphdb.configs | default dict) }}
 ---
-apiVersion: {{ $.Values.versions.statefulset }}
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: graphdb-node
@@ -233,7 +233,7 @@ spec:
               echo 'Done'
 
 ---
-apiVersion: {{ $.Values.versions.service }}
+apiVersion: v1
 kind: Service
 metadata:
   name: graphdb-node

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -97,6 +97,12 @@ spec:
         - name: graphdb-node
           image: {{ include "graphdb.renderFullImageName" (dict "globalRegistry" $.Values.global.imageRegistry "image" $.Values.images.graphdb) }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          {{- with .Values.graphdb.node.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.args }}
+          args: {{ toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: graphdb
               containerPort: 7200

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -230,3 +230,23 @@ spec:
       targetPort: 7300
       protocol: TCP
     {{- end }}
+
+{{- if .Values.graphdb.pdb.create }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: graphdb-node
+  labels:
+    {{- include "graphdb.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.graphdb.pdb.minAvailable }}
+  minAvailable: {{ .Values.graphdb.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.graphdb.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.graphdb.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: graphdb-node
+{{- end }}

--- a/templates/graphdb-provision-user-secret.yaml
+++ b/templates/graphdb-provision-user-secret.yaml
@@ -1,5 +1,5 @@
 # Secret used from the jobs to authenticate to running GraphDB instances
-apiVersion: {{ .Values.versions.secret }}
+apiVersion: v1
 kind: Secret
 metadata:
   name: graphdb-provision-user

--- a/templates/graphdb-utils-configmap.yaml
+++ b/templates/graphdb-utils-configmap.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ .Values.versions.configmap }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: graphdb-utils-configmap

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-apiVersion: {{ $.Values.versions.job }}
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: patch-cluster-job

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-apiVersion: {{ $.Values.versions.job }}
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-graphdb-cluster-job

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -1,6 +1,6 @@
 {{- $configs := (.Values.graphdb.configs | default dict) }}
 {{- if $configs.provisionRepositoriesConfigMap }}
-apiVersion: {{ $.Values.versions.job }}
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: provision-repositories-job

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ $.Values.versions.job }}
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: scale-down-cluster-job

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.graphdb.clusterConfig.nodesCount) 1 }}
-apiVersion: {{ $.Values.versions.job }}
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: scale-up-cluster-job

--- a/values.yaml
+++ b/values.yaml
@@ -10,22 +10,6 @@ global:
   storageClass: "standard"
   imageRegistry: docker.io
 
-# K8S API versions differ on Kubernetes and local Minikube installation.
-# Please, refer to: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
-versions:
-  api: apps/v1
-  service: v1
-  ingress: networking.k8s.io/v1
-  deployment: apps/v1
-  statefulset: apps/v1
-  secret: v1
-  configmap: v1
-  volume: v1
-  job: batch/v1
-  daemon: apps/v1
-  pvc: v1
-  pv: v1
-
 # Top lvl flat for easier maintenance
 images:
   graphdb:

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ deployment:
   imagePullPolicy: IfNotPresent
   # Secret used to pull Docker images. Uncomment to use it.
   # Important: Must be created beforehand
-  # imagePullSecret: ontotext5
+  # imagePullSecret: ontotext
 
   # -- The storage place where components will read/write their persistent data in case the default
   # persistent volumes are used. They use the node's file system.
@@ -190,6 +190,10 @@ graphdb:
     revisionHistoryLimit: 10
     # grace period in seconds before terminating the pods
     terminationGracePeriodSeconds: 120
+    # overrides the default container command, use only for troubleshooting!
+    command:
+    # overrides the default container command's arguments, use only for troubleshooting!
+    args:
 
   # -- Settings for the GraphDB cluster proxy used to communicate with the GraphDB cluster
   # Note: If there is no cluster (graphdb.clusterConfig.nodesCount is set to 1) no proxy will be deployed

--- a/values.yaml
+++ b/values.yaml
@@ -137,14 +137,13 @@ graphdb:
             storage: "5Gi"
     # -- Below are minimum requirements for data sets of up to 50 million RDF triples
     # For resizing, refer according to the GraphDB documentation
-    # http://graphdb.ontotext.com/documentation/requirements.html
+    # https://graphdb.ontotext.com/documentation/10.2/requirements.html
     resources:
       limits:
         memory: 2Gi
-        cpu: 2000m
       requests:
         memory: 2Gi
-        cpu: 2000m
+        cpu: 0.5
     # -- Configurations for the GraphDB node startup probe. Misconfigured probe can lead to a failing cluster.
     startupProbe:
       httpGet:
@@ -215,10 +214,9 @@ graphdb:
     resources:
       limits:
         memory: 1500Mi
-        cpu: 800m
       requests:
         memory: 1500Mi
-        cpu: 800m
+        cpu: 100m
     # -- Persistence configurations.
     # By default, Helm will use a PV that reads and writes to the host file system.
     persistence:

--- a/values.yaml
+++ b/values.yaml
@@ -30,9 +30,6 @@ deployment:
   # Important: Must be created beforehand
   # imagePullSecret: ontotext
 
-  # -- The storage place where components will read/write their persistent data in case the default
-  # persistent volumes are used. They use the node's file system.
-  storage: /data
   # -- The hostname and protocol at which the graphdb will be accessible.
   # Needed to configure ingress as well as some components require it to properly render their UIs
   protocol: http

--- a/values.yaml
+++ b/values.yaml
@@ -288,3 +288,10 @@ graphdb:
       resources:
         requests:
           storage: "10Gi"
+
+  # Pod Disruption Budget for GraphDB nodes
+  # See https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+  pdb:
+    create: false
+    minAvailable: "51%"
+    maxUnavailable:


### PR DESCRIPTION
Changes:

- GDB-8328: Removed versions field: There isn't any practical need for having apiVersion as configurations.
- GDB-7983: Enriched Chart.yaml info: Added additional meta information about the chart.
- GDB-8216: Directly mounted the license: No need to provision it via initContainer when it can just be mounted.
- GDB-8308: Added configurations for graphdb-node command and args: The configurations can be useful during troubleshooting.
- Removed unused persistence configurations
  - Removed unused graphdb-node-storage volume mount
  - Removed unused deployment.storage config
- GDB-7989: Added Pod Disruption Budget for the GraphDB nodes
- GDB-8038: Tuned resource requests and limits
  - Removed CPU limits which is an anti-pattern
  - Lowered the default CPU requests