### PR TITLE
feat: #64 allow specifying resource requests/limits for all (remainin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GraphDB Helm chart release notes
 
+## Version 10.2.3-R1
+
+- Added configurations for specifying resource values for all remaining containers, see `graphdb.node.initContainerResources` and `graphdb.jobResources`.
+
 ## Version 10.2.2
 
 ### New

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -160,6 +160,9 @@ spec:
           {{- with .Values.graphdb.node.initContainerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.graphdb.node.initContainerResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           command: ['sh', '-c']
           args:
             - |
@@ -204,6 +207,9 @@ spec:
             {{- end }}
           {{- with .Values.graphdb.node.initContainerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.initContainerResources }}
+          resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           command: ['sh', '-c']
           args:

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -26,6 +26,9 @@ spec:
             - secretRef:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.jobResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: job-temp
               mountPath: /tmp

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -26,6 +26,9 @@ spec:
             - secretRef:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.jobResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: job-temp
               mountPath: /tmp

--- a/templates/jobs/provision-repositories-job.yaml
+++ b/templates/jobs/provision-repositories-job.yaml
@@ -27,6 +27,9 @@ spec:
             - secretRef:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.jobResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: job-temp
               mountPath: /tmp

--- a/templates/jobs/scale-down-cluster-job.yaml
+++ b/templates/jobs/scale-down-cluster-job.yaml
@@ -24,6 +24,9 @@ spec:
             - secretRef:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.jobResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: job-temp
               mountPath: /tmp

--- a/templates/jobs/scale-up-cluster-job.yaml
+++ b/templates/jobs/scale-up-cluster-job.yaml
@@ -26,6 +26,9 @@ spec:
             - secretRef:
                 name: graphdb-provision-user
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
+          {{- with .Values.graphdb.jobResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: job-temp
               mountPath: /tmp

--- a/values.yaml
+++ b/values.yaml
@@ -127,6 +127,8 @@ graphdb:
   jobPodSecurityContext: {}
   # jobContainerSecurityContext defines privilege and access control settings for all the job containers
   jobSecurityContext: {}
+  # jobResources defines resource requests and limits for all the job containers
+  jobResources: {}
 
   # -- Settings for the GraphDB cluster nodes
   node:
@@ -202,6 +204,8 @@ graphdb:
     securityContext: {}
     # provisionSecurityContext defines privilege and access control settings for the node containers provisioning configurations for graphdb.
     initContainerSecurityContext: {}
+    # initContainerResources defines resource requests and limits for the node containers provisioning configurations for graphdb.
+    initContainerResources: {}
     # changes the maximum amount of kept revisions
     revisionHistoryLimit: 10
     # grace period in seconds before terminating the pods


### PR DESCRIPTION
Due to company policies we need to be able to specify resource requests & limits for all containers of the graphdb Helm chart deployment. This MR enables it.

Fixes #64 

Not sure how you handle versioning and the Changelog; let me know if I should need to change anything, or edit yourself.