### PR TITLE
Added configurations for extra service annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GraphDB Helm chart release notes
 
+## Version 10.3.0-R2
+
+### New
+
+- Added configurations for extra service annotations, see `graphdb.node.service.annotations`, `graphdb.clusterProxy.service.annotations`
+  and `graphdb.clusterProxy.headlessService.annotations`
+
 ## Version 10.2.3
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is an enterprise ready Semantic Graph Database
 type: application
-version: 10.3.0
+version: 10.3.0-R2
 appVersion: 10.3.0
 kubeVersion: ^1.22.0-0
 home: https://graphdb.ontotext.com/

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -115,6 +115,10 @@ metadata:
   labels:
     app: graphdb-cluster-proxy
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.graphdb.clusterProxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ $.Values.graphdb.clusterProxy.serviceType }}
   selector:
@@ -132,6 +136,10 @@ metadata:
   labels:
     app: graphdb-cluster-proxy
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.graphdb.clusterProxy.headlessService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   selector:

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -215,6 +215,10 @@ metadata:
   labels:
     app: graphdb-node
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.graphdb.node.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   selector:

--- a/values.yaml
+++ b/values.yaml
@@ -125,6 +125,10 @@ graphdb:
     # Extra pod labels and annotations
     podLabels: {}
     podAnnotations: {}
+    # -- GraphDB node service configurations
+    service:
+      # Extra annotations to append to the service
+      annotations: {}
     # -- Persistence configurations.
     # By default, Helm will use a PV that reads and writes to the host file system.
     persistence:
@@ -210,6 +214,14 @@ graphdb:
     # Extra pod labels and annotations
     podLabels: {}
     podAnnotations: {}
+    # -- GraphDB cluster proxy service configurations
+    service:
+      # Extra annotations to append to the service
+      annotations: {}
+    # -- GraphDB cluster proxy headless service configurations
+    headlessService:
+      # Extra annotations to append to the service
+      annotations: {}
     # -- Minimum requirements for a successfully running GraphDB cluster proxy
     resources:
       limits:


### PR DESCRIPTION
The configurations cover:

- GraphDB node service `graphdb.node.service.annotations`
- GraphDB cluster proxy service `graphdb.clusterProxy.service.annotations`
- GraphDB cluster proxy headless service `graphdb.clusterProxy.headlessService.annotations`