### PR TITLE
Fixed "How to configure Hosts file" broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ the Minikube environment is `192.168.99.102` you should modify your hosts file w
 192.168.99.102  graphdb.local
 ```
 
-See this how-to https://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/
+See this how-to https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/
 about modifying the hosts file in different OS.
 
 #### Secrets


### PR DESCRIPTION
The original URL now leads to a 404 page. 
I've modified the URL so it points to the correct address. 