### PR TITLE
GDB-9190: Extra init containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New
 
 - Added `graphdb.node.licenseFilename` for cases where the default filename is not "graphdb.license"
+- Added `graphdb.node.extraInitContainers` and `graphdb.clusterProxy.extraInitContainers` that allows for the insertion of custom init containers to 
+  both GraphDB and its proxy
 
 ### Improvements
 

--- a/templates/graphdb-cluster-proxy.yaml
+++ b/templates/graphdb-cluster-proxy.yaml
@@ -62,6 +62,10 @@ spec:
       {{- end }}
       imagePullSecrets:
         {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
+      {{- with .Values.graphdb.clusterProxy.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: graphdb-proxy
           image: {{ include "graphdb.image" . }}

--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -209,7 +209,9 @@ spec:
               fi
               mkdir -p /opt/graphdb/home/jdbc-driver
               echo 'Done'
-
+        {{- with .Values.graphdb.node.extraInitContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/values.yaml
+++ b/values.yaml
@@ -186,6 +186,8 @@ graphdb:
     extraVolumes: []
     # additional volume mounts to be set for the graphdb nodes
     extraVolumeMounts: []
+    # additional init containers inserted after the provisioning init containers
+    extraInitContainers: []
     # podSecurityContext defines privilege and access control settings for the node pods.
     podSecurityContext: {}
     # securityContext defines privilege and access control settings for the node container running graphdb.
@@ -280,6 +282,8 @@ graphdb:
     extraVolumes: []
     # additional volume mounts to be set for each cluster proxy
     extraVolumeMounts: []
+    # additional init containers
+    extraInitContainers: []
     # podSecurityContext defines privilege and access control settings for the proxy pods.
     podSecurityContext: {}
     # securityContext defines privilege and access control settings for the proxy containers.


### PR DESCRIPTION
Added `graphdb.node.extraInitContainers` and `graphdb.clusterProxy.extraInitContainers` that allows for the insertion of custom init containers to both GraphDB and its proxy.