### PR TITLE
GDB-9509: Updated the cluster creation JSON configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # GraphDB Helm chart release notes
 
+## Version 10.6.0-R2
+
+### New
+
+- Added `graphdb.node.extraInitContainers` and `graphdb.clusterProxy.extraInitContainers` that allows for the insertion of custom init containers to
+  both GraphDB and its proxy
+- Added `graphdb.clusterConfig.transactionLogMaximumSizeGB` configuration for the cluster creation JSON configuration.
+- Added `graphdb.clusterConfig.existingClusterConfig` for providing a custom cluster creation JSON configuration.
+
+### Fixed
+
+- Fixed URLs in the [README.md](README.md) that refer to the official GraphDB documentation.
+- Fixed the cluster creation JSON configuration to use `messageSizeKB` instead of `messageSize`, see `graphdb.clusterConfig.messageSize`.
+
 ## Version 10.6.0
 
 ### New
 
 - Added `graphdb.node.licenseFilename` for cases where the default filename is not "graphdb.license"
-- Added `graphdb.node.extraInitContainers` and `graphdb.clusterProxy.extraInitContainers` that allows for the insertion of custom init containers to 
-  both GraphDB and its proxy
 
 ### Improvements
 

--- a/files/config/cluster-config.json
+++ b/files/config/cluster-config.json
@@ -1,11 +1,12 @@
 {
-  "electionMinTimeout": {{ $.Values.graphdb.clusterConfig.electionMinTimeout }},
-  "electionRangeTimeout": {{ $.Values.graphdb.clusterConfig.electionRangeTimeout }},
-  "heartbeatInterval": {{ $.Values.graphdb.clusterConfig.heartbeatInterval }},
-  "messageSize": {{ $.Values.graphdb.clusterConfig.messageSize }},
-  "verificationTimeout": {{ $.Values.graphdb.clusterConfig.verificationTimeout }},
+  "electionMinTimeout": {{ .Values.graphdb.clusterConfig.electionMinTimeout | int }},
+  "electionRangeTimeout": {{ .Values.graphdb.clusterConfig.electionRangeTimeout | int }},
+  "heartbeatInterval": {{ .Values.graphdb.clusterConfig.heartbeatInterval | int }},
+  "verificationTimeout": {{ .Values.graphdb.clusterConfig.verificationTimeout | int }},
+  "messageSizeKB": {{ .Values.graphdb.clusterConfig.messageSize | int }},
+  "transactionLogMaximumSizeGB": {{ .Values.graphdb.clusterConfig.transactionLogMaximumSizeGB | quote }},
   "nodes": [
-    {{- range $i, $node_index := until ( (int $.Values.graphdb.clusterConfig.nodesCount) )}}
+    {{- range $i, $node_index := until (int .Values.graphdb.clusterConfig.nodesCount) }}
     "graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7300"{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},
     {{- end }}
     {{- end }}

--- a/templates/configuration/graphdb-cluster-config-configmap.yaml
+++ b/templates/configuration/graphdb-cluster-config-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
+{{- if and (gt (int $.Values.graphdb.clusterConfig.nodesCount) 1) (not .Values.graphdb.clusterConfig.existingClusterConfig) }}
 # Default configuration map for provisioning the GraphDB cluster configuration.
 # To change it, prepare another configuration map and update "graphdb.configs.clusterConfig"
 apiVersion: v1

--- a/templates/jobs/patch-cluster-job.yaml
+++ b/templates/jobs/patch-cluster-job.yaml
@@ -48,7 +48,7 @@ spec:
             sizeLimit: 10Mi
         - name: cluster-config
           configMap:
-            name: graphdb-cluster-config-configmap
+            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default "graphdb-cluster-config-configmap" }}
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap

--- a/templates/jobs/post-start-job.yaml
+++ b/templates/jobs/post-start-job.yaml
@@ -49,7 +49,7 @@ spec:
             sizeLimit: 10Mi
         - name: cluster-config
           configMap:
-            name: graphdb-cluster-config-configmap
+            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default "graphdb-cluster-config-configmap" }}
         - name: graphdb-utils
           configMap:
             name: graphdb-utils-configmap

--- a/values.yaml
+++ b/values.yaml
@@ -73,20 +73,26 @@ graphdb:
     # -- Timeout for the cluster creation CURL query.
     # Note: By default helm waits for Kubernetes commands to complete for 5 minutes. You can increase that by adding "--timeout 10m" to the helm command.
     clusterCreationTimeout: 60
+    # -- Use a custom JSON configuration when creating the cluster, see https://graphdb.ontotext.com/documentation/10.6/creating-a-cluster.html#creation-parameters
+    # The resources expect a configmap containing a key "cluster-config.json" with the JSON for cluster creation
+    existingClusterConfig:
     # -- Cluster configuration parameters:
+    # Refer to https://graphdb.ontotext.com/documentation/10.6/creating-a-cluster.html#creation-parameters
     # The minimum wait time in milliseconds for a heartbeat from a leader.
     electionMinTimeout: 8000
     # The variable portion of each waiting period in milliseconds for a heartbeat.
     electionRangeTimeout: 6000
     # The interval in milliseconds between each heartbeat that is sent to follower nodes by the leader.
     heartbeatInterval: 2000
-    #The size of the data blocks transferred during data replication streaming through the RPC protocol.
+    # The size in KB of the data blocks transferred during data replication streaming through the RPC protocol.
     messageSize: 64
+    # Maximum size of the transaction log in GBs. The transaction log will be automatically truncated if it becomes bigger than this value.
+    transactionLogMaximumSizeGB: 50
     # The amount of time in milliseconds a follower node would wait before attempting to verify the last committed entry when the first verification is unsuccessful.
     verificationTimeout: 1500
 
   # -- References to configuration maps containing settings.js, users.js, graphdb.properties, and logback.xml files to overwrite
-  # the default GraphDB configuration. For reference see https://graphdb.ontotext.com/documentation/standard/configuring-graphdb.html
+  # the default GraphDB configuration. For reference see https://graphdb.ontotext.com/documentation/10.6/directories-and-config-properties.html
   configs:
     # Override default settings configuration
     #settingsConfigMap: graphdb-settings-configmap
@@ -147,7 +153,7 @@ graphdb:
             storage: "5Gi"
     # -- Below are minimum requirements for data sets of up to 50 million RDF triples
     # For resizing, refer according to the GraphDB documentation
-    # https://graphdb.ontotext.com/documentation/10.2/requirements.html
+    # https://graphdb.ontotext.com/documentation/10.6/requirements.html
     resources:
       limits:
         memory: 2Gi
@@ -301,7 +307,7 @@ graphdb:
 
   # WARNING: Setting enabled to true in most cloud providers will result in an error
   # Attach additional PV which will be used as an import directory
-  # https://graphdb.ontotext.com/documentation/standard/loading-data-using-the-workbench.html#importing-server-files
+  # https://graphdb.ontotext.com/documentation/10.6/loading-data-using-the-workbench.html#importing-server-files
   import_directory_mount:
     enabled: false
     volumeClaimTemplateSpec:


### PR DESCRIPTION
- Added `graphdb.clusterConfig.transactionLogMaximumSizeGB` configuration for the cluster creation JSON configuration
- Added `graphdb.clusterConfig.existingClusterConfig` for providing a custom cluster creation JSON configuration
- Fixed URLs in the [README.md](README.md) that refer to the official GraphDB documentation
- Fixed the cluster creation JSON configuration to use `messageSizeKB` instead of `messageSize`, see `graphdb.clusterConfig.messageSize`