### PR TITLE
GDB-7982: Resource names and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,28 @@
 
 ## Version 11.0.0
 
+TODO: short motivational paragraph about the major version
+TODO: short info about being decoupled from GraphDB
+
 ### New
 
+- Added `annotations` for common annotations across resources
 - Added `graphdb.serviceAccount` allowing you to create or use an existing service account for GraphDB pods.
+- Values in `labels` and `annotations` are now evaluated as templates
+- Added separate `labels` and `annotations` for the cluster proxy
+- Added GraphDB and GraphDB proxy hostnames resolution in the init containers
+
+### Updates
+
+- GraphDB properties and logback configuration configmaps are now applied by default
 
 ### Breaking
 
 - Renamed `extraLabels` to just `labels`
+- Renamed GraphDB storage PVC prefix to `graphdb-storage` and server import folder to `graphdb-server-import`
+- Resource names are no longer hardcoded and are using the templates for `nameOverride` and `fullnameOverride`
+- Removed setting FQDN as hostnames in GraphDB and the proxy in favor of dynamically resolving and configuring the hostnames in the init containers
+- Configmaps from `graphdb.configs` are now under `configuration` and with a different structure allowing better reuse of existing configmaps
 
 ## Version 10.6.0-R2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `graphdb.serviceAccount` allowing you to create or use an existing service account for GraphDB pods.
 
+### Breaking
+
+- Renamed `extraLabels` to just `labels`
+
 ## Version 10.6.0-R2
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 11.0.0
+
+### New
+
+- Added `graphdb.serviceAccount` allowing you to create or use an existing service account for GraphDB pods.
+
 ## Version 10.6.0-R2
 
 ### New

--- a/README.md
+++ b/README.md
@@ -470,6 +470,11 @@ about defining resource limits.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| annotations | object | `{}` |  |
+| configuration.logback.configmapKey | string | `"logback.xml"` |  |
+| configuration.logback.existingConfigmap | string | `""` |  |
+| configuration.properties.configmapKey | string | `"graphdb.properties"` |  |
+| configuration.properties.existingConfigmap | string | `""` |  |
 | deployment.host | string | `"localhost"` |  |
 | deployment.imagePullPolicy | string | `"IfNotPresent"` | Defines the policy with which components will request their image. |
 | deployment.ingress | object | `{"annotations":{},"class":"nginx","enabled":true,"maxRequestSize":"512M","timeout":{"connect":5,"read":600,"send":600}}` | Ingress related configurations |
@@ -479,7 +484,7 @@ about defining resource limits.
 | deployment.protocol | string | `"http"` | The hostname and protocol at which the graphdb will be accessible. Needed to configure ingress as well as some components require it to properly render their UIs |
 | deployment.tls.enabled | bool | `false` | Feature toggle for SSL termination. Disabled by default. If TLS is enabled, the protocol should also be updated (https) |
 | deployment.tls.secretName | string | `nil` | Name of a Kubernetes secret object with the key and certificate. If TLS is enabled, it's required to be provided, depending on the deployment. |
-| extraLabels | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
 | global.imagePullSecrets | list | `[]` |  |
 | global.imageRegistry | string | `"docker.io"` |  |
 | global.storageClass | string | `"standard"` |  |
@@ -518,7 +523,7 @@ about defining resource limits.
 | graphdb.clusterProxy.terminationGracePeriodSeconds | int | `30` |  |
 | graphdb.clusterProxy.tolerations | list | `[]` |  |
 | graphdb.clusterProxy.topologySpreadConstraints | list | `[]` |  |
-| graphdb.configs | string | `nil` | References to configuration maps containing settings.js, users.js, graphdb.properties, and logback.xml files to overwrite the default GraphDB configuration. For reference see https://graphdb.ontotext.com/documentation/10.6/directories-and-config-properties.html |
+| graphdb.configs | object | `{"provisionRepositoriesConfigMap":""}` | References to configuration maps containing settings.js, users.js, graphdb.properties, and logback.xml files to overwrite the default GraphDB configuration. For reference see https://graphdb.ontotext.com/documentation/10.6/directories-and-config-properties.html |
 | graphdb.import_directory_mount.enabled | bool | `false` |  |
 | graphdb.import_directory_mount.volumeClaimTemplateSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | graphdb.import_directory_mount.volumeClaimTemplateSpec.resources.requests.storage | string | `"10Gi"` |  |
@@ -559,12 +564,25 @@ about defining resource limits.
 | graphdb.security.enabled | bool | `false` |  |
 | graphdb.security.provisioningPassword | string | `"iHaveSuperpowers"` |  |
 | graphdb.security.provisioningUsername | string | `"provisioner"` |  |
+| graphdb.serviceAccount.annotations | object | `{}` |  |
+| graphdb.serviceAccount.create | bool | `true` |  |
+| graphdb.serviceAccount.name | string | `""` |  |
 | graphdb.workbench.subpath | string | `"/graphdb"` | This is the sub path at which GraphDB workbench can be opened. Should be configured in the API gateway (or any other proxy in front) |
 | images.busybox.repository | string | `"busybox"` |  |
 | images.busybox.tag | string | `"1.36.1"` |  |
 | images.graphdb.registry | string | `"docker.io"` |  |
 | images.graphdb.repository | string | `"ontotext/graphdb"` |  |
 | images.graphdb.tag | string | `""` |  |
+| labels | object | `{}` |  |
+| nameOverride | string | `""` |  |
+| provision.settings.configmapKey | string | `"settings.js"` |  |
+| provision.settings.existingConfigmap | string | `""` |  |
+| provision.users.configmapKey | string | `"users.js"` |  |
+| provision.users.existingConfigmap | string | `""` |  |
+| proxy.annotations | object | `{}` |  |
+| proxy.fullnameOverride | string | `""` |  |
+| proxy.labels | object | `{}` |  |
+| proxy.nameOverride | string | `""` |  |
 
 ## Uninstall
 To remove the deployed GraphDB, use:

--- a/files/config/cluster-config.json
+++ b/files/config/cluster-config.json
@@ -6,9 +6,6 @@
   "messageSizeKB": {{ .Values.graphdb.clusterConfig.messageSize | int }},
   "transactionLogMaximumSizeGB": {{ .Values.graphdb.clusterConfig.transactionLogMaximumSizeGB | quote }},
   "nodes": [
-    {{- range $i, $node_index := until (int .Values.graphdb.clusterConfig.nodesCount) }}
-    "graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7300"{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},
-    {{- end }}
-    {{- end }}
+    {{- include "graphdb.cluster.nodes.json" . | nindent 4 }}
   ]
 }

--- a/files/config/proxy/graphdb.properties
+++ b/files/config/proxy/graphdb.properties
@@ -65,10 +65,7 @@
 # List the addresses of GraphDB HTTP or RPC address to the nodes that are part of a cluster
 # Note that all of the addresses need to be from the same cluster
 
-
-graphdb.proxy.hosts={{- range $i, $node_index := until ( (int $.Values.graphdb.clusterConfig.nodesCount) )}}http://graphdb-node-{{ $node_index }}.graphdb-node.{{ $.Release.Namespace }}.svc.cluster.local:7200{{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index }},{{- end }}
-{{- end }}
-
+graphdb.proxy.hosts={{ include "graphdb-proxy.cluster.nodes" . }}
 
 # The number of times a request to be retried to a different node in the cluster, when a node is not reachable, before failing the request.
 # If a request could be handled by other node, other than the initial one, then other node from the cluster will be

--- a/files/scripts/graphdb.sh
+++ b/files/scripts/graphdb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 function createCluster {
@@ -6,8 +7,15 @@ function createCluster {
   local configLocation=$2
   local authToken=$PROVISION_USER_AUTH_TOKEN
   local timeout=$3
+
   echo "Creating cluster"
-  curl -o response.json -isSL -m $timeout -X POST --header "Authorization: Basic ${authToken}" --header 'Content-Type: application/json' --header 'Accept: */*' -d @"$configLocation" http://graphdb-node-0.graphdb-node:7200/rest/cluster/config
+  curl -o response.json -isSL -m $timeout -X POST \
+       -d @"$configLocation" \
+       --header "Authorization: Basic ${authToken}" \
+       --header 'Content-Type: application/json' \
+       --header 'Accept: */*' \
+       "http://${GRAPHDB_POD_NAME}-0.${GRAPHDB_SERVICE_NAME}:7200/rest/cluster/config"
+
   if grep -q 'HTTP/1.1 201' "response.json"; then
     echo "Cluster creation successful!"
   elif grep -q 'Cluster already exists.\|HTTP/1.1 409' "response.json" ; then
@@ -46,8 +54,7 @@ function waitAllNodes {
   for (( c=$node_count; c>0; c ))
   do
     c=$((c-1))
-    local node_address=http://graphdb-node-$c.graphdb-node:7200
-    waitService "${node_address}/rest/repositories"
+    waitService "http://${GRAPHDB_POD_NAME}-$c.${GRAPHDB_SERVICE_NAME}:7200/rest/repositories"
   done
 }
 
@@ -56,12 +63,21 @@ function createRepositoryFromFile {
   local repositoriesConfigsLocation=$2
   local authToken=$PROVISION_USER_AUTH_TOKEN
   local timeout=60
-  echo "Creating repositories"
   local success=true
+
+  echo "Creating repositories"
   for filename in ${repositoriesConfigsLocation}/*.ttl; do
     repositoryName=$(grep "rep:repositoryID" $filename | sed -ne 's/rep:repositoryID "//p' | sed -ne 's/" ;//p' | sed -ne 's/^[[:space:]]*//p')
+
     echo "Provisioning repository ${repositoryName}"
-    response=$(curl -X POST --connect-timeout 60 --retry 3 --retry-all-errors --retry-delay 10 -H "Authorization: Basic ${authToken}" -H 'Content-Type: multipart/form-data' -F config=@${filename}  http://graphdb-node-0.graphdb-node:7200/rest/repositories)
+    response=$(
+      curl -X POST --connect-timeout 60 --retry 3 --retry-all-errors --retry-delay 10 \
+           -F config=@${filename} \
+           -H "Authorization: Basic ${authToken}" \
+           -H 'Content-Type: multipart/form-data' \
+           "http://${GRAPHDB_POD_NAME}-0.${GRAPHDB_SERVICE_NAME}:7200/rest/repositories"
+    )
+
     if [ -z "$response" ]; then
       echo "Successfully created repository ${repositoryName}"
     else

--- a/files/scripts/update-cluster.sh
+++ b/files/scripts/update-cluster.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
+
 set -eu
 
 function patchCluster {
   local configLocation=$1
   local authToken=$PROVISION_USER_AUTH_TOKEN
   local timeout=$2
+
   echo "Patching cluster"
-  waitService "http://graphdb-cluster-proxy:7200/proxy/ready"
-  curl -o patchResponse.json -isSL -m "$timeout" -X PATCH  --header "Authorization: Basic ${authToken}" --header 'Content-Type: application/json' --header 'Accept: application/json' -d @"$configLocation" 'http://graphdb-cluster-proxy:7200/rest/cluster/config'
-    if grep -q 'HTTP/1.1 200' "patchResponse.json"; then
-      echo "Patch successful"
-    elif grep -q 'Cluster does not exist.\|HTTP/1.1 412' "patchResponse.json" ; then
-      echo "Cluster does not exist"
-    else
-      echo "Cluster patch failed, received response:"
-      cat patchResponse.json
-      echo
-      exit 1
-    fi
+  waitService "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/proxy/ready"
+  curl -o patchResponse.json -isSL -m "$timeout" -X PATCH \
+       --header "Authorization: Basic ${authToken}" \
+       --header 'Content-Type: application/json' \
+       --header 'Accept: application/json' \
+       -d @"$configLocation" \
+       "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/rest/cluster/config"
+
+  if grep -q 'HTTP/1.1 200' "patchResponse.json"; then
+    echo "Patch successful"
+  elif grep -q 'Cluster does not exist.\|HTTP/1.1 412' "patchResponse.json" ; then
+    echo "Cluster does not exist"
+  else
+    echo "Cluster patch failed, received response:"
+    cat patchResponse.json
+    echo
+    exit 1
+  fi
 }
 
 function removeNodes {
@@ -28,17 +36,20 @@ function removeNodes {
   local nodes=""
   echo "Cluster reported: $currentNodes current nodes"
   echo "Cluster is expected to have: $expectedNodes nodes"
-# if there is no cluster or current nodes are less or equal to expected so no need to remove more, exit
+
+  # if there is no cluster or current nodes are less or equal to expected so no need to remove more, exit
   if [ "$currentNodes" -lt 2 ] || [ "$currentNodes" -le "$expectedNodes" ]; then
     echo "No scaling down of the cluster required"
     exit 0
   fi
-# if there is a cluster and we wanna scale to 1 node, delete it (we would have exit on the last if in case on no cluster)
+
+  # if there is a cluster and we wanna scale to 1 node, delete it (we would have exit on the last if in case on no cluster)
   if [ "$expectedNodes" -lt 2 ]; then
     echo "Scaling down to 1 node. Deleting cluster"
     deleteCluster
     exit 0
   fi
+
   echo "Scaling the cluster down"
   for ((i = expectedNodes; i < currentNodes; i++)) do
     nodes=${nodes}\"graphdb-node-$i.graphdb-node.${namespace}.svc.cluster.local:7300\"
@@ -46,9 +57,16 @@ function removeNodes {
       nodes=${nodes}\,
     fi
   done
+
   nodes=\{\"nodes\":\[${nodes}\]\}
-  waitService "http://graphdb-cluster-proxy:7200/proxy/ready"
-  curl -o clusterRemove.json -isSL -m 15 -X DELETE --header 'Content-Type: application/json' --header 'Accept: application/json' --header "Authorization: Basic ${authToken}" -d "${nodes}"  'http://graphdb-cluster-proxy:7200/rest/cluster/config/node'
+  waitService "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/proxy/ready"
+  curl -o clusterRemove.json -isSL -m 15 -X DELETE \
+       --header 'Content-Type: application/json' \
+       --header 'Accept: application/json' \
+       --header "Authorization: Basic ${authToken}" \
+       -d "${nodes}" \
+       "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/rest/cluster/config/node"
+
   if grep -q 'HTTP/1.1 200' "clusterRemove.json"; then
     echo "Scaling down successful."
   else
@@ -68,11 +86,13 @@ function addNodes {
   local nodes=""
   echo "Cluster reported: $currentNodes current nodes"
   echo "Cluster is expected to have: $expectedNodes nodes"
-# if there is no cluster or current nodes are more or equal to expected so no need to add more, exit
+
+  # if there is no cluster or current nodes are more or equal to expected so no need to add more, exit
   if [ "$currentNodes" -lt 2 ] || [ "$currentNodes" -ge "$expectedNodes" ]; then
     echo "No scaling up of the cluster required"
     exit 0
   fi
+
   echo "Scaling the cluster up"
   for ((i = currentNodes; i < expectedNodes; i++)) do
     nodes=${nodes}\"graphdb-node-$i.graphdb-node.${namespace}.svc.cluster.local:7300\"
@@ -80,9 +100,16 @@ function addNodes {
       nodes=${nodes}\,
     fi
   done
+
   nodes=\{\"nodes\":\[${nodes}\]\}
-  waitService "http://graphdb-cluster-proxy:7200/proxy/ready"
-  curl -o clusterAdd.json -isSL -m ${timeout} -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header "Authorization: Basic ${authToken}" -d "${nodes}"  'http://graphdb-cluster-proxy:7200/rest/cluster/config/node'
+  waitService "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/proxy/ready"
+  curl -o clusterAdd.json -isSL -m ${timeout} -X POST \
+       --header 'Content-Type: application/json' \
+       --header 'Accept: application/json' \
+       --header "Authorization: Basic ${authToken}" \
+       -d "${nodes}" \
+       "http://${GRAPHDB_PROXY_SERVICE_NAME}:7200/rest/cluster/config/node"
+
   if grep -q 'HTTP/1.1 200' "clusterAdd.json"; then
     echo "Scaling successful."
   elif grep -q 'Mismatching fingerprints\|HTTP/1.1 412' "clusterAdd.json"; then
@@ -101,8 +128,12 @@ function addNodes {
 
 function deleteCluster {
   local authToken=$PROVISION_USER_AUTH_TOKEN
-  waitService "http://graphdb-node-0.graphdb-node:7200/rest/repositories"
-  curl -o response.json -isSL -m 15 -X DELETE --header "Authorization: Basic ${authToken}" --header 'Accept: */*' 'http://graphdb-node-0.graphdb-node:7200/rest/cluster/config?force=false'
+  waitService "http://${GRAPHDB_POD_NAME}-0.${GRAPHDB_SERVICE_NAME}:7200/rest/repositories"
+  curl -o response.json -isSL -m 15 -X DELETE \
+       --header "Authorization: Basic ${authToken}" \
+       --header 'Accept: */*' \
+       "http://${GRAPHDB_POD_NAME}-0.${GRAPHDB_SERVICE_NAME}:7200/rest/cluster/config?force=false"
+
   if grep -q 'HTTP/1.1 200' "response.json"; then
     echo "Cluster deletion successful!"
   elif grep -q 'Node is not part of the cluster.\|HTTP/1.1 412' "response.json" ; then
@@ -117,9 +148,13 @@ function deleteCluster {
 
 function getNodeCountInCurrentCluster {
   local authToken=$PROVISION_USER_AUTH_TOKEN
-  local node_address=http://graphdb-node-0.graphdb-node:7200
+  local node_address="http://${GRAPHDB_POD_NAME}-0.${GRAPHDB_SERVICE_NAME}:7200"
   waitService "${node_address}/rest/repositories"
-  curl -o clusterResponse.json -isSL -m 15 -X GET --header 'Content-Type: application/json' --header "Authorization: Basic ${authToken}" --header 'Accept: */*' "${node_address}/rest/cluster/config"
+  curl -o clusterResponse.json -isSL -m 15 -X GET \
+       --header 'Content-Type: application/json' \
+       --header "Authorization: Basic ${authToken}" \
+       --header 'Accept: */*' \
+       "${node_address}/rest/cluster/config"
   grep -o 'graphdb-node-' "clusterResponse.json" | grep -c ""
 }
 

--- a/templates/_helpers.yaml
+++ b/templates/_helpers.yaml
@@ -5,6 +5,13 @@
 {{- end }}
 
 {{/*
+Renders the URL address at which GraphDB would be accessed
+*/}}
+{{- define "graphdb.url.public" -}}
+{{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
+{{- end }}
+
+{{/*
 Combined image pull secrets
 */}}
 {{- define "graphdb.combinedImagePullSecrets" -}}
@@ -52,3 +59,27 @@ Render the container image for GraphDB
     {{- printf "%s:%s" $repository $tag -}}
   {{- end -}}
 {{- end }}
+
+{{/*
+Renders the gRPC address of each GraphDB node that is part of the cluster. Used in the cluster JSON config.
+*/}}
+{{- define "graphdb.cluster.nodes.json" -}}
+  {{- range $i, $node_index := until (int .Values.graphdb.clusterConfig.nodesCount) -}}
+    "{{ include "graphdb.fullname" $ }}-{{ $node_index }}.{{ include "graphdb.fullname.service.headless" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:7300"
+    {{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index -}}
+      {{- ", \n" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Renders the HTTP address of each GraphDB node that is part of the cluster, joined by a comma.
+*/}}
+{{- define "graphdb-proxy.cluster.nodes" -}}
+  {{- range $i, $node_index := until (int $.Values.graphdb.clusterConfig.nodesCount) -}}
+    http://{{ include "graphdb.fullname" $ }}-{{ $node_index }}.{{ include "graphdb.fullname.service.headless" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:7200
+    {{- if gt (sub (int $.Values.graphdb.clusterConfig.nodesCount) 1 ) $node_index -}}
+      {{- ", " -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/templates/_labels.yaml
+++ b/templates/_labels.yaml
@@ -40,8 +40,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: graphdb
 app.kubernetes.io/part-of: graphdb
-{{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels }}
 {{- end }}
 {{- end }}
 

--- a/templates/_labels.yaml
+++ b/templates/_labels.yaml
@@ -52,3 +52,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "graphdb.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "graphdb.serviceAccountName" -}}
+  {{- if .Values.graphdb.serviceAccount.create }}
+    {{- default (include "graphdb.fullname" .) .Values.graphdb.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.graphdb.serviceAccount.name }}
+  {{- end }}
+{{- end }}

--- a/templates/_labels.yaml
+++ b/templates/_labels.yaml
@@ -41,7 +41,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/component: graphdb
 app.kubernetes.io/part-of: graphdb
 {{- if .Values.labels }}
-{{ toYaml .Values.labels }}
+{{ tpl ( toYaml .Values.labels ) $ }}
 {{- end }}
 {{- end }}
 

--- a/templates/graphdb/_labels.tpl
+++ b/templates/graphdb/_labels.tpl
@@ -1,0 +1,23 @@
+{{/*
+Helper functions for labels related to GraphDB resources
+*/}}
+
+{{- define "graphdb.fullname.configmap.logback" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "logback" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.configmap.properties" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "properties" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.configmap.settings" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "settings" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.configmap.users" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "users" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.service.headless" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "headless" -}}
+{{- end -}}

--- a/templates/graphdb/configmap-logback.yaml
+++ b/templates/graphdb/configmap-logback.yaml
@@ -1,16 +1,15 @@
-{{- $configs := (.Values.graphdb.configs | default dict) }}
-{{- if $configs.logbackConfigMap }}
-{{- if eq $configs.logbackConfigMap "graphdb-logback-configmap" }}
-# Default configuration map for provisioning GraphDB logback settings.
-# To change it, prepare another configuration map and update "graphdb.configs.logbackConfigMap"
+{{- if not .Values.configuration.logback.existingConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-logback-configmap
+  name: {{ include "graphdb.fullname.configmap.logback" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
-  logback.xml: |-
-{{ tpl (.Files.Get "files/config/logback.xml" | indent 4) . }}
-{{- end }}
+  {{ .Values.configuration.logback.configmapKey }}: |-
+    {{- tpl ( .Files.Get "files/config/logback.xml" ) . | nindent 4 }}
 {{- end }}

--- a/templates/graphdb/configmap-properties.yaml
+++ b/templates/graphdb/configmap-properties.yaml
@@ -1,16 +1,15 @@
-{{- $configs := (.Values.graphdb.configs | default dict) }}
-{{- if $configs.propertiesConfigMap}}
-{{- if eq $configs.propertiesConfigMap "graphdb-properties-configmap" }}
-# Default configuration map for provisioning GraphDB properties.
-# To change it, prepare another configuration map and update "graphdb.configs.propertiesConfigMap"
+{{- if not .Values.configuration.properties.existingConfigmap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-properties-configmap
+  name: {{ include "graphdb.fullname.configmap.properties" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
-  graphdb.properties: |-
-{{ tpl (.Files.Get "files/config/graphdb.properties" | indent 4) . }}
-{{- end }}
+  {{ .Values.configuration.properties.configmapKey }}: |-
+    {{- tpl ( .Files.Get "files/config/graphdb.properties" ) . | nindent 4 }}
 {{- end }}

--- a/templates/graphdb/configmap-settings.yaml
+++ b/templates/graphdb/configmap-settings.yaml
@@ -1,15 +1,15 @@
-{{- $configs := (.Values.graphdb.configs | default dict) }}
-{{- $settingsConfigMap := $configs.settingsConfigMap | default "" }}
-{{- if or (eq $settingsConfigMap "graphdb-settings-configmap") (and (not $settingsConfigMap ) (.Values.graphdb.security.enabled)) }}
-# Default configuration map for provisioning GraphDB settings.js file.
-# To change it, prepare another configuration map and update "graphdb.configs.settingsConfigMap"
+{{- if and .Values.graphdb.security.enabled (not .Values.provision.settings.existingConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-settings-configmap
+  name: {{ include "graphdb.fullname.configmap.settings" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
-  settings.js: |-
-{{ tpl (.Files.Get "files/config/settings.js" | indent 4) . }}
+  {{ .Values.provision.settings.configmapKey }}: |-
+    {{- tpl ( .Files.Get "files/config/settings.js" ) . | nindent 4 }}
 {{- end }}

--- a/templates/graphdb/configmap-users.yaml
+++ b/templates/graphdb/configmap-users.yaml
@@ -1,15 +1,15 @@
-{{- $configs := (.Values.graphdb.configs | default dict) }}
-{{- $usersConfigMap := $configs.usersConfigMap | default ""}}
-{{- if or (eq $usersConfigMap "graphdb-users-configmap") (and (not $usersConfigMap) (.Values.graphdb.security.enabled)) }}
-# Default configuration map for provisioning GraphDB users.js file.
-# To change it, prepare another configuration map and update "graphdb.configs.usersConfigMap"
+{{- if and .Values.graphdb.security.enabled (not .Values.provision.users.existingConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-users-configmap
+  name: {{ include "graphdb.fullname.configmap.users" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
-  users.js: |-
-{{ tpl (.Files.Get "files/config/users.js" | indent 4) . }}
+  {{ .Values.provision.users.configmapKey }}: |-
+    {{- tpl ( .Files.Get "files/config/users.js" ) . | nindent 4 }}
 {{- end }}

--- a/templates/graphdb/configmap.yaml
+++ b/templates/graphdb/configmap.yaml
@@ -1,23 +1,24 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-node-configmap
+  name: {{ include "graphdb.fullname" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
   # >- means replace new line with space and no new lines at the end
   GDB_JAVA_OPTS: >-
     -Denable-context-index=true
     -Dentity-pool-implementation=transactional
     -Dhealth.max.query.time.seconds=60
-    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.append.request.id.headers=true
     -Dgraphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
     -Dgraphdb.home=/opt/graphdb/home
     -Dgraphdb.ontop.jdbc.path=/opt/graphdb/home/jdbc-driver
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
     -Dgraphdb.auth.token.secret={{ $.Values.graphdb.clusterConfig.clusterSecret | quote }}
-{{- else }}
-    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
 {{- end }}
     {{ default $.Values.graphdb.node.java_args}}

--- a/templates/graphdb/pdb.yaml
+++ b/templates/graphdb/pdb.yaml
@@ -2,9 +2,13 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: graphdb-node
+  name: {{ include "graphdb.fullname" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.graphdb.pdb.minAvailable }}
   minAvailable: {{ .Values.graphdb.pdb.minAvailable }}
@@ -14,5 +18,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: graphdb-node
+      {{- include "graphdb.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/templates/graphdb/service-headless.yaml
+++ b/templates/graphdb/service-headless.yaml
@@ -1,18 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: graphdb-node
+  name: {{ include "graphdb.fullname.service.headless" . }}
   labels:
-    app: graphdb-node
     {{- include "graphdb.labels" . | nindent 4 }}
-  {{- with .Values.graphdb.node.service.annotations }}
+  {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.graphdb.node.service.annotations) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   clusterIP: None
   selector:
-    app: graphdb-node
+    {{- include "graphdb.selectorLabels" . | nindent 4 }}
   ports:
     - name: graphdb
       port: 7200

--- a/templates/graphdb/serviceaccount.yaml
+++ b/templates/graphdb/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.graphdb.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "graphdb.serviceAccountName" . }}
+  labels:
+    {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.graphdb.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/graphdb/serviceaccount.yaml
+++ b/templates/graphdb/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "graphdb.serviceAccountName" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
-  {{- with .Values.graphdb.serviceAccount.annotations }}
+  {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.graphdb.serviceAccount.annotations) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end -}}
 {{- end }}

--- a/templates/graphdb/statefulset.yaml
+++ b/templates/graphdb/statefulset.yaml
@@ -47,6 +47,7 @@ spec:
     spec:
       setHostnameAsFQDN: true
       terminationGracePeriodSeconds: {{ .Values.graphdb.node.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "graphdb.serviceAccountName" . }}
       volumes:
         {{- if .Values.graphdb.node.license }}
         - name: graphdb-license

--- a/templates/graphdb/statefulset.yaml
+++ b/templates/graphdb/statefulset.yaml
@@ -1,33 +1,34 @@
-{{- $configs := ($.Values.graphdb.configs | default dict) }}
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: graphdb-node
+  name: {{ include "graphdb.fullname" . }}
   labels:
-    app: graphdb-node
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ $.Values.graphdb.clusterConfig.nodesCount }}
-  serviceName: graphdb-node
+  serviceName: {{ include "graphdb.fullname.service.headless" . }}
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
   revisionHistoryLimit: {{ .Values.graphdb.node.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: graphdb-node
-  {{- if or (hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec") ($.Values.graphdb.import_directory_mount.enabled)}}
+      {{- include "graphdb.selectorLabels" . | nindent 6 }}
+  {{- if or (hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec") ($.Values.graphdb.import_directory_mount.enabled) }}
   volumeClaimTemplates:
     {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
     - metadata:
-        name: graphdb-node-data-dynamic-pvc
+        name: graphdb-storage
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.node.persistence.volumeClaimTemplateSpec }}
       spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
     {{- if $.Values.graphdb.import_directory_mount.enabled }}
     - metadata:
-        name: graphdb-server-import-dir
+        name: graphdb-server-import
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.import_directory_mount.volumeClaimTemplateSpec }}
       spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
@@ -35,44 +36,40 @@ spec:
   template:
     metadata:
       labels:
-        app: graphdb-node
+        {{- include "graphdb.selectorLabels" . | nindent 8 }}
         {{- with .Values.graphdb.node.podLabels }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/graphdb/configmap.yaml") . | sha256sum }}
         {{- with .Values.graphdb.node.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
     spec:
-      setHostnameAsFQDN: true
+      setHostnameAsFQDN: false
       terminationGracePeriodSeconds: {{ .Values.graphdb.node.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "graphdb.serviceAccountName" . }}
       volumes:
+        - name: graphdb-properties
+          configMap:
+            name: {{ .Values.configuration.properties.existingConfigmap | default ( include "graphdb.fullname.configmap.properties" . ) }}
+        - name: graphdb-logback-config
+          configMap:
+            name: {{ .Values.configuration.logback.existingConfigmap | default ( include "graphdb.fullname.configmap.logback" . ) }}
         {{- if .Values.graphdb.node.license }}
         - name: graphdb-license
           secret:
             secretName: {{ .Values.graphdb.node.license }}
         {{- end }}
-        {{- if or $configs.settingsConfigMap $.Values.graphdb.security.enabled }}
-        - name: graphdb-settings-config
+        {{- if or .Values.graphdb.security.enabled .Values.provision.settings.existingConfigmap }}
+        - name: graphdb-initial-settings-config
           configMap:
-            name: {{ $configs.settingsConfigMap | default "graphdb-settings-configmap" }}
+            name: {{ .Values.provision.settings.existingConfigmap | default ( include "graphdb.fullname.configmap.settings" . ) }}
         {{- end }}
-        {{- if or $configs.usersConfigMap $.Values.graphdb.security.enabled }}
-        - name: graphdb-users-config
+        {{- if or .Values.graphdb.security.enabled .Values.provision.users.existingConfigmap }}
+        - name: graphdb-initial-users-config
           configMap:
-            name: {{ $configs.usersConfigMap | default "graphdb-users-configmap" }}
-        {{- end }}
-        {{- if $configs.propertiesConfigMap }}
-        - name: graphdb-properties-config
-          configMap:
-            name: {{ $configs.propertiesConfigMap }}
-        {{- end }}
-        {{- if $configs.logbackConfigMap }}
-        - name: graphdb-logback-config
-          configMap:
-            name: {{ $configs.logbackConfigMap }}
+            name: {{ .Values.provision.users.existingConfigmap | default ( include "graphdb.fullname.configmap.users" . ) }}
         {{- end }}
         {{- with $.Values.graphdb.node.extraVolumes }}
           {{- tpl ( toYaml . ) $ | nindent 8 }}
@@ -95,7 +92,7 @@ spec:
       imagePullSecrets:
         {{- include "graphdb.combinedImagePullSecrets" $ | nindent 8 }}
       containers:
-        - name: graphdb-node
+        - name: {{ .Chart.Name }}
           image: {{ include "graphdb.image" . }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           {{- with .Values.graphdb.node.command }}
@@ -113,7 +110,7 @@ spec:
               {{- end }}
           envFrom:
             - configMapRef:
-                name: graphdb-node-configmap
+                name: {{ include "graphdb.fullname" . }}
             {{- with $.Values.graphdb.node.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
@@ -122,16 +119,19 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
-            - name: graphdb-node-data-dynamic-pvc
+            - name: graphdb-storage
               mountPath: /opt/graphdb/home
             {{- end }}
+            - name: graphdb-logback-config
+              mountPath: /opt/graphdb/home/conf/logback.xml
+              subPath: {{ .Values.configuration.logback.configmapKey }}
             {{- if .Values.graphdb.node.license }}
             - name: graphdb-license
               mountPath: /opt/graphdb/home/conf/graphdb.license
               subPath: {{ .Values.graphdb.node.licenseFilename }}
             {{- end }}
             {{- if $.Values.graphdb.import_directory_mount.enabled }}
-            - name: graphdb-server-import-dir
+            - name: graphdb-server-import
               mountPath: /opt/graphdb/home/graphdb-import
             {{- end }}
             {{- with $.Values.graphdb.node.extraVolumeMounts }}
@@ -154,29 +154,29 @@ spec:
           {{- end }}
       initContainers:
         # PROVISION SETTINGS AND SECURITY
-        - name: provision-settings
+        - name: {{ .Chart.Name }}-provision-settings
           image: {{ include "graphdb.image" . }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          env:
+            - name: GRAPHDB_PUBLIC_URL
+              value: {{ include "graphdb.url.public" . }}
           volumeMounts:
             {{- if hasKey $.Values.graphdb.node.persistence "volumeClaimTemplateSpec" }}
-            - name: graphdb-node-data-dynamic-pvc
+            - name: graphdb-storage
               mountPath: /opt/graphdb/home
             {{- end }}
-            {{- if or $configs.settingsConfigMap $.Values.graphdb.security.enabled }}
-            - name: graphdb-settings-config
-              mountPath: /tmp/graphdb-settings-configmap
+            - name: graphdb-properties
+              mountPath: /tmp/graphdb/graphdb.properties
+              subPath: {{ .Values.configuration.properties.configmapKey }}
+            {{- if or .Values.graphdb.security.enabled .Values.provision.settings.existingConfigmap }}
+            - name: graphdb-initial-settings-config
+              mountPath: /tmp/graphdb/settings.js
+              subPath: {{ .Values.provision.settings.configmapKey }}
             {{- end }}
-            {{- if or $configs.usersConfigMap $.Values.graphdb.security.enabled }}
-            - name: graphdb-users-config
-              mountPath: /tmp/graphdb-users-configmap
-            {{- end }}
-            {{- if $configs.propertiesConfigMap }}
-            - name: graphdb-properties-config
-              mountPath: /tmp/graphdb-properties-configmap
-            {{- end }}
-            {{- if $configs.logbackConfigMap }}
-            - name: graphdb-logback-config
-              mountPath: /tmp/graphdb-logback-configmap
+            {{- if or .Values.graphdb.security.enabled .Values.provision.settings.existingConfigmap }}
+            - name: graphdb-initial-users-config
+              mountPath: /tmp/graphdb/users.js
+              subPath: {{ .Values.provision.users.configmapKey }}
             {{- end }}
           {{- with .Values.graphdb.node.initContainerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
@@ -184,31 +184,31 @@ spec:
           {{- with .Values.graphdb.node.initContainerResources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
-          command: ['sh', '-c']
+          command: [ 'sh', '-c' ]
           args:
             - |
               set -eu
-              if [[ ! -f /opt/graphdb/home/work/workbench/settings.js && ! -f /opt/graphdb/home/data/users.js && -f /tmp/graphdb-users-configmap/users.js ]]; then
+              mkdir -p /opt/graphdb/home/conf/ /opt/graphdb/home/data/ /opt/graphdb/home/jdbc-driver/
+
+              echo 'Configuring graphdb.properties'
+              cat /tmp/graphdb/graphdb.properties > /opt/graphdb/home/conf/graphdb.properties
+              echo "" >> /opt/graphdb/home/conf/graphdb.properties
+
+              echo "Configuring GraphDB hostname: $(hostname --fqdn)"
+              echo "graphdb.vhosts=$(hostname --fqdn):7200, ${GRAPHDB_PUBLIC_URL}" >> /opt/graphdb/home/conf/graphdb.properties
+              echo "graphdb.hostname=$(hostname --fqdn)" >> /opt/graphdb/home/conf/graphdb.properties
+              echo "graphdb.rpc.address=$(hostname --fqdn):7300" >> /opt/graphdb/home/conf/graphdb.properties
+
+              if [[ ! -f /opt/graphdb/home/work/workbench/settings.js && ! -f /opt/graphdb/home/data/users.js && -f /tmp/graphdb/users.js ]]; then
                 echo "Provisioning users with users.js file..."
-                mkdir -p /opt/graphdb/home/data ;
-                cp /tmp/graphdb-users-configmap/users.js /opt/graphdb/home/data/users.js
+                cp /tmp/graphdb/users.js /opt/graphdb/home/data/users.js
               fi
-              if [[ ! -f /opt/graphdb/home/work/workbench/settings.js && ! -f /opt/graphdb/home/data/settings.js && -f /tmp/graphdb-settings-configmap/settings.js ]]; then
+
+              if [[ ! -f /opt/graphdb/home/work/workbench/settings.js && ! -f /opt/graphdb/home/data/settings.js && -f /tmp/graphdb/settings.js ]]; then
                 echo "Provisioning settings with settings.js file..."
-                mkdir -p /opt/graphdb/home/data ;
-                cp /tmp/graphdb-settings-configmap/settings.js /opt/graphdb/home/data/settings.js
+                cp /tmp/graphdb/settings.js /opt/graphdb/home/data/settings.js
               fi
-              if [[ -f /tmp/graphdb-properties-configmap/graphdb.properties ]]; then
-                echo "Provisioning graphdb properties file..."
-                mkdir -p /opt/graphdb/home/conf ;
-                cp /tmp/graphdb-properties-configmap/graphdb.properties /opt/graphdb/home/conf/graphdb.properties
-              fi
-              if [[ -f /tmp/graphdb-logback-configmap/logback.xml ]]; then
-                echo "Provisioning logging config file..."
-                mkdir -p /opt/graphdb/home/conf ;
-                cp /tmp/graphdb-logback-configmap/logback.xml /opt/graphdb/home/conf/logback.xml
-              fi
-              mkdir -p /opt/graphdb/home/jdbc-driver
+
               echo 'Done'
         {{- with .Values.graphdb.node.extraInitContainers }}
           {{- toYaml . | nindent 8 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress
+  name: {{ include "graphdb.fullname" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
@@ -20,8 +20,8 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- end }}
     nginx.ingress.kubernetes.io/x-forwarded-prefix: {{ $.Values.graphdb.workbench.subpath | quote }}
-    {{- with .Values.deployment.ingress.annotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- with (mergeOverwrite (deepCopy .Values.annotations) .Values.deployment.ingress.annotations) }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.deployment.tls.enabled }}
@@ -43,9 +43,9 @@ spec:
             backend:
               service:
               {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
-                name: graphdb-cluster-proxy
+                name: {{ include "graphdb-proxy.fullname" . }}
               {{- else }}
-                name: graphdb-node
+                name: {{ include "graphdb.fullname.service.headless" . }}
               {{- end }}
                 port:
                   number: 7200

--- a/templates/jobs/_labels.tpl
+++ b/templates/jobs/_labels.tpl
@@ -1,0 +1,36 @@
+{{/*
+Helper functions for labels related to Job and provisioning resources
+*/}}
+
+{{- define "graphdb.fullname.configmap.cluster" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "cluster" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.configmap.utils" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "utils" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.secret.provision-user" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "provision-user" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.job.create-cluster" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "create-cluster" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.job.patch-cluster" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "patch-cluster" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.job.provision-repositories" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "provision-repositories" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.job.scale-down-cluster" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "scale-down-cluster" -}}
+{{- end -}}
+
+{{- define "graphdb.fullname.job.scale-up-cluster" -}}
+  {{- printf "%s-%s" ( include "graphdb.fullname" . ) "scale-up-cluster" -}}
+{{- end -}}
+

--- a/templates/jobs/configmap-cluster-config.yaml
+++ b/templates/jobs/configmap-cluster-config.yaml
@@ -4,10 +4,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-cluster-config-configmap
+  name: {{ include "graphdb.fullname.configmap.cluster" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
   cluster-config.json: |-
-{{ tpl (.Files.Get "files/config/cluster-config.json" | indent 4) . }}
+    {{- tpl ( .Files.Get "files/config/cluster-config.json" ) . | nindent 4 }}
 {{- end }}

--- a/templates/jobs/configmap-utils.yaml
+++ b/templates/jobs/configmap-utils.yaml
@@ -1,16 +1,18 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-utils-configmap
+  name: {{ include "graphdb.fullname.configmap.utils" . }}
   labels:
-    name: graphdb-utils-configmap
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade, pre-rollback, post-install, post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "-10"
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 data:
   graphdb.sh: |-
-{{ tpl (.Files.Get "files/scripts/graphdb.sh" | indent 4) . }}
+    {{- tpl (.Files.Get "files/scripts/graphdb.sh" ) . | nindent 4 }}
   update-cluster.sh: |-
-{{ tpl (.Files.Get "files/scripts/update-cluster.sh" | indent 4) . }}
+    {{- tpl (.Files.Get "files/scripts/update-cluster.sh" ) . | nindent 4 }}

--- a/templates/jobs/job-create-cluster.yaml
+++ b/templates/jobs/job-create-cluster.yaml
@@ -2,13 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: create-graphdb-cluster-job
+  name: {{ include "graphdb.fullname.job.create-cluster" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "-1"
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 9
@@ -22,9 +25,14 @@ spec:
       containers:
         - name: create-graphdb-cluster
           image: {{ include "graphdb.image" . }}
+          env:
+            - name: GRAPHDB_POD_NAME
+              value: {{ include "graphdb.fullname" . }}
+            - name: GRAPHDB_SERVICE_NAME
+              value: {{ include "graphdb.fullname.service.headless" . }}
           envFrom:
             - secretRef:
-                name: graphdb-provision-user
+                name: {{ include "graphdb.fullname.secret.provision-user" . }}
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           {{- with .Values.graphdb.jobResources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -49,8 +57,8 @@ spec:
             sizeLimit: 10Mi
         - name: cluster-config
           configMap:
-            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default "graphdb-cluster-config-configmap" }}
+            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default ( include "graphdb.fullname.configmap.cluster" . ) }}
         - name: graphdb-utils
           configMap:
-            name: graphdb-utils-configmap
+            name: {{ include "graphdb.fullname.configmap.utils" . }}
 {{- end }}

--- a/templates/jobs/job-patch-cluster.yaml
+++ b/templates/jobs/job-patch-cluster.yaml
@@ -2,13 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: patch-cluster-job
+  name: {{ include "graphdb.fullname.job.patch-cluster" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "2"
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 4
@@ -22,9 +25,16 @@ spec:
       containers:
         - name: patch-cluster
           image: {{ include "graphdb.image" . }}
+          env:
+            - name: GRAPHDB_POD_NAME
+              value: {{ include "graphdb.fullname" . }}
+            - name: GRAPHDB_SERVICE_NAME
+              value: {{ include "graphdb.fullname.service.headless" . }}
+            - name: GRAPHDB_PROXY_SERVICE_NAME
+              value: {{ include "graphdb-proxy.fullname" . }}
           envFrom:
             - secretRef:
-                name: graphdb-provision-user
+                name: {{ include "graphdb.fullname.secret.provision-user" . }}
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           {{- with .Values.graphdb.jobResources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -48,8 +58,8 @@ spec:
             sizeLimit: 10Mi
         - name: cluster-config
           configMap:
-            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default "graphdb-cluster-config-configmap" }}
+            name: {{ .Values.graphdb.clusterConfig.existingClusterConfig | default ( printf "%s-cluster" (include "graphdb.fullname" . ) ) }}
         - name: graphdb-utils
           configMap:
-            name: graphdb-utils-configmap
+            name: {{ include "graphdb.fullname.configmap.utils" . }}
 {{- end }}

--- a/templates/jobs/job-provision-repositories.yaml
+++ b/templates/jobs/job-provision-repositories.yaml
@@ -1,15 +1,17 @@
-{{- $configs := (.Values.graphdb.configs | default dict) }}
-{{- if $configs.provisionRepositoriesConfigMap }}
+{{- if .Values.graphdb.configs.provisionRepositoriesConfigMap }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: provision-repositories-job
+  name: {{ include "graphdb.fullname.job.provision-repositories" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "4"
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 3
@@ -23,9 +25,14 @@ spec:
       containers:
         - name: provision-repositories
           image: {{ include "graphdb.image" . }}
+          env:
+            - name: GRAPHDB_POD_NAME
+              value: {{ include "graphdb.fullname" . }}
+            - name: GRAPHDB_SERVICE_NAME
+              value: {{ include "graphdb.fullname.service.headless" . }}
           envFrom:
             - secretRef:
-                name: graphdb-provision-user
+                name: {{ include "graphdb.fullname.secret.provision-user" . }}
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           {{- with .Values.graphdb.jobResources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -52,5 +59,5 @@ spec:
             name: {{ .Values.graphdb.configs.provisionRepositoriesConfigMap }}
         - name: graphdb-utils
           configMap:
-            name: graphdb-utils-configmap
+            name: {{ include "graphdb.fullname.configmap.utils" . }}
 {{- end }}

--- a/templates/jobs/job-scale-down-cluster.yaml
+++ b/templates/jobs/job-scale-down-cluster.yaml
@@ -1,12 +1,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: scale-down-cluster-job
+  name: {{ include "graphdb.fullname.job.scale-down-cluster" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade, pre-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 4
@@ -20,9 +23,16 @@ spec:
       containers:
         - name: scale-down-cluster
           image: {{ include "graphdb.image" . }}
+          env:
+            - name: GRAPHDB_POD_NAME
+              value: {{ include "graphdb.fullname" . }}
+            - name: GRAPHDB_SERVICE_NAME
+              value: {{ include "graphdb.fullname.service.headless" . }}
+            - name: GRAPHDB_PROXY_SERVICE_NAME
+              value: {{ include "graphdb-proxy.fullname" . }}
           envFrom:
             - secretRef:
-                name: graphdb-provision-user
+                name: {{ include "graphdb.fullname.secret.provision-user" . }}
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           {{- with .Values.graphdb.jobResources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -44,4 +54,4 @@ spec:
             sizeLimit: 10Mi
         - name: graphdb-utils
           configMap:
-            name: graphdb-utils-configmap
+            name: {{ include "graphdb.fullname.configmap.utils" . }}

--- a/templates/jobs/job-scale-up-cluster.yaml
+++ b/templates/jobs/job-scale-up-cluster.yaml
@@ -2,13 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: scale-up-cluster-job
+  name: {{ include "graphdb.fullname.job.scale-up-cluster" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "1"
+    {{- with .Values.annotations }}
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 spec:
   ttlSecondsAfterFinished: 300
   backoffLimit: 4
@@ -22,9 +25,16 @@ spec:
       containers:
         - name: scale-up-cluster
           image: {{ include "graphdb.image" . }}
+          env:
+            - name: GRAPHDB_POD_NAME
+              value: {{ include "graphdb.fullname" . }}
+            - name: GRAPHDB_SERVICE_NAME
+              value: {{ include "graphdb.fullname.service.headless" . }}
+            - name: GRAPHDB_PROXY_SERVICE_NAME
+              value: {{ include "graphdb-proxy.fullname" . }}
           envFrom:
             - secretRef:
-                name: graphdb-provision-user
+                name: {{ include "graphdb.fullname.secret.provision-user" . }}
           securityContext: {{- $.Values.graphdb.jobSecurityContext | toYaml | nindent 12 }}
           {{- with .Values.graphdb.jobResources }}
           resources: {{ toYaml . | nindent 12 }}
@@ -47,5 +57,5 @@ spec:
             sizeLimit: 10Mi
         - name: graphdb-utils
           configMap:
-            name: graphdb-utils-configmap
+            name: {{ include "graphdb.fullname.configmap.utils" . }}
 {{- end }}

--- a/templates/jobs/secret-provision-user.yaml
+++ b/templates/jobs/secret-provision-user.yaml
@@ -2,13 +2,17 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: graphdb-provision-user
+  name: {{ include "graphdb.fullname.secret.provision-user" . }}
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade, pre-rollback, post-install, post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     "helm.sh/hook-weight": "-9"
+    {{- with .Values.annotations }}
+    annotations:
+      {{- tpl ( toYaml . ) $ | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
   provisioningUsername: {{ .Values.graphdb.security.provisioningUsername | b64enc | quote }}

--- a/templates/proxy/_labels.tpl
+++ b/templates/proxy/_labels.tpl
@@ -1,0 +1,62 @@
+{{/*
+Creates another chart name for the proxy service to distinguish it from GraphDB.
+*/}}
+{{- define "graphdb-proxy.chartName" -}}
+{{- printf "%s-proxy" .Chart.Name -}}
+{{- end }}
+
+{{/*
+Expand the name of the proxy service.
+*/}}
+{{- define "graphdb-proxy.name" -}}
+{{- default ( include "graphdb-proxy.chartName" . ) .Values.proxy.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for the proxy service.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "graphdb-proxy.fullname" -}}
+{{- if .Values.proxy.fullnameOverride }}
+{{- .Values.proxy.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default ( include "graphdb-proxy.chartName" . ) .Values.proxy.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels for the proxy service.
+*/}}
+{{- define "graphdb-proxy.labels" -}}
+helm.sh/chart: {{ include "graphdb.chart" . }}
+{{ include "graphdb-proxy.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: graphdb-proxy
+app.kubernetes.io/part-of: graphdb
+{{- if .Values.proxy.labels }}
+{{ tpl ( toYaml .Values.proxy.labels ) $ }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels for the proxy service.
+*/}}
+{{- define "graphdb-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "graphdb-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "graphdb-proxy.fullname.configmap.properties" -}}
+  {{- printf "%s-%s" ( include "graphdb-proxy.fullname" . ) "properties" -}}
+{{- end -}}
+
+{{- define "graphdb-proxy.fullname.service.headless" -}}
+  {{- printf "%s-%s" ( include "graphdb-proxy.fullname" . ) "headless" -}}
+{{- end -}}

--- a/templates/proxy/configmap-properties.yaml
+++ b/templates/proxy/configmap-properties.yaml
@@ -2,10 +2,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-proxy-properties-configmap
+  name: {{ include "graphdb-proxy.fullname.configmap.properties" . }}
   labels:
-    {{- include "graphdb.labels" . | nindent 4 }}
+    {{- include "graphdb-proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxy.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
   graphdb.properties: |-
-{{ tpl (.Files.Get "files/config/proxy/graphdb.properties" | indent 4) . }}
+    {{- tpl ( .Files.Get "files/config/proxy/graphdb.properties" ) . | nindent 4 }}
 {{- end }}

--- a/templates/proxy/configmap.yaml
+++ b/templates/proxy/configmap.yaml
@@ -2,14 +2,16 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: graphdb-cluster-proxy-configmap
+  name: {{ include "graphdb-proxy.fullname" . }}
   labels:
-    {{- include "graphdb.labels" . | nindent 4 }}
+    {{- include "graphdb-proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxy.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 data:
   # >- means replace new line with space and no new lines at the end
   GDB_JAVA_OPTS: >-
-    -Dgraphdb.vhosts={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
-    -Dgraphdb.external-url={{ $.Values.deployment.protocol }}://{{ include "graphdb.resolveDeploymentHost" $ }}{{ $.Values.graphdb.workbench.subpath }}
     -Dgraphdb.auth.token.secret={{ $.Values.graphdb.clusterConfig.clusterSecret | quote }}
     -Dgraphdb.home=/opt/graphdb/home
     {{ $.Values.graphdb.clusterProxy.java_args }}

--- a/templates/proxy/service-headless.yaml
+++ b/templates/proxy/service-headless.yaml
@@ -2,18 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: graphdb-proxy
+  name: {{ include "graphdb-proxy.fullname.service.headless" . }}
   labels:
-    app: graphdb-cluster-proxy
-    {{- include "graphdb.labels" . | nindent 4 }}
-  {{- with .Values.graphdb.clusterProxy.headlessService.annotations }}
+    {{- include "graphdb-proxy.labels" . | nindent 4 }}
+  {{- with (mergeOverwrite (deepCopy .Values.proxy.annotations) .Values.graphdb.clusterProxy.headlessService.annotations) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   clusterIP: None
   selector:
-    app: graphdb-cluster-proxy
+    {{- include "graphdb-proxy.selectorLabels" . | nindent 4 }}
   ports:
     - name: gdb-proxy-rpc
       port: 7300

--- a/templates/proxy/service.yaml
+++ b/templates/proxy/service.yaml
@@ -2,18 +2,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: graphdb-cluster-proxy
+  name: {{ include "graphdb-proxy.fullname" . }}
   labels:
-    app: graphdb-cluster-proxy
-    {{- include "graphdb.labels" . | nindent 4 }}
-  {{- with .Values.graphdb.clusterProxy.service.annotations }}
+    {{- include "graphdb-proxy.labels" . | nindent 4 }}
+  {{- with (mergeOverwrite (deepCopy .Values.proxy.annotations) .Values.graphdb.clusterProxy.service.annotations) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
   {{- end }}
 spec:
   type: {{ $.Values.graphdb.clusterProxy.serviceType }}
   selector:
-    app: graphdb-cluster-proxy
+    {{- include "graphdb-proxy.selectorLabels" . | nindent 4 }}
   ports:
     - name: gdb-proxy-port
       port: 7200

--- a/templates/proxy/statefulset.yaml
+++ b/templates/proxy/statefulset.yaml
@@ -1,47 +1,48 @@
 {{- if gt (int $.Values.graphdb.clusterConfig.nodesCount) 1 }}
-{{- $configs := ($.Values.graphdb.configs | default dict) }}
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: gdb-proxy
+  name: {{ include "graphdb-proxy.fullname" . }}
   labels:
-    app: graphdb-cluster-proxy
-    {{- include "graphdb.labels" . | nindent 4 }}
+    {{- include "graphdb-proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxy.annotations }}
+  annotations:
+    {{- tpl ( toYaml . ) $ | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ $.Values.graphdb.clusterProxy.replicas }}
-  serviceName: graphdb-proxy
+  serviceName: {{ include "graphdb-proxy.fullname.service.headless" . }}
   podManagementPolicy: Parallel
   revisionHistoryLimit: {{ .Values.graphdb.clusterProxy.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: graphdb-cluster-proxy
+      {{- include "graphdb-proxy.selectorLabels" . | nindent 6 }}
   volumeClaimTemplates:
     {{- if $.Values.graphdb.clusterProxy.persistence.enablePersistence }}
     - metadata:
-        name: graphdb-cluster-proxy-data-dynamic-pvc
+        name: graphdb-storage
       {{- $spec := dict "globalStorageClassName" $.Values.global.storageClass "spec" $.Values.graphdb.clusterProxy.persistence.volumeClaimTemplateSpec }}
       spec: {{ include "graphdb.renderVolumeClaimTemplateSpec" $spec | nindent 8 }}
     {{- end }}
   template:
     metadata:
       labels:
-        app: graphdb-cluster-proxy
+        {{- include "graphdb-proxy.selectorLabels" . | nindent 8 }}
         {{- with .Values.graphdb.clusterProxy.podLabels }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/proxy/configmap.yaml") . | sha256sum }}
         {{- with .Values.graphdb.clusterProxy.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{- tpl ( toYaml . ) $ | nindent 8 }}
         {{- end }}
     spec:
+      setHostnameAsFQDN: false
       terminationGracePeriodSeconds: {{ .Values.graphdb.clusterProxy.terminationGracePeriodSeconds }}
-      setHostnameAsFQDN: true
       volumes:
         - name: graphdb-properties
           configMap:
-            name: graphdb-proxy-properties-configmap
+            name: {{ include "graphdb-proxy.fullname.configmap.properties" . }}
       {{- with $.Values.graphdb.clusterProxy.extraVolumes }}
         {{- tpl ( toYaml . ) $ | nindent 8 }}
       {{- end }}
@@ -67,13 +68,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: graphdb-proxy
+        - name: {{ include "graphdb-proxy.chartName" . }}
           image: {{ include "graphdb.image" . }}
           imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
           command: ["/opt/graphdb/dist/bin/cluster-proxy"]
           envFrom:
             - configMapRef:
-                name: graphdb-cluster-proxy-configmap
+                name: {{ include "graphdb-proxy.fullname" . }}
             {{- with $.Values.graphdb.clusterProxy.extraEnvFrom }}
               {{- tpl ( toYaml . ) $ | nindent 12 }}
             {{- end }}
@@ -86,11 +87,8 @@ spec:
             - name: gdb-proxy-rpc
               containerPort: 7300
           volumeMounts:
-            - name: graphdb-properties
-              mountPath: /opt/graphdb/home/conf/graphdb.properties
-              subPath: graphdb.properties
             {{- if $.Values.graphdb.clusterProxy.persistence.enablePersistence }}
-            - name: graphdb-cluster-proxy-data-dynamic-pvc
+            - name: graphdb-storage
               mountPath: /opt/graphdb/home
             {{- end }}
             {{- with $.Values.graphdb.clusterProxy.extraVolumeMounts }}
@@ -111,4 +109,42 @@ spec:
           {{- with .Values.graphdb.clusterProxy.livenessProbe }}
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}
+      initContainers:
+        - name: {{ include "graphdb-proxy.chartName" . }}-provision-settings
+          image: {{ include "graphdb.image" . }}
+          imagePullPolicy: {{ $.Values.deployment.imagePullPolicy }}
+          env:
+            - name: GRAPHDB_PUBLIC_URL
+              value: {{ include "graphdb.url.public" . }}
+          {{- with .Values.graphdb.node.initContainerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.graphdb.node.initContainerResources }}
+          resources: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: graphdb-properties
+              mountPath: /tmp/graphdb.properties
+              subPath: graphdb.properties
+            {{- if $.Values.graphdb.clusterProxy.persistence.enablePersistence }}
+            - name: graphdb-storage
+              mountPath: /opt/graphdb/home
+            {{- end }}
+          command: [ 'sh', '-c' ]
+          args:
+            - |
+              set -eu
+              mkdir -p /opt/graphdb/home/conf/
+
+              echo 'Configuring graphdb.properties'
+              cat /tmp/graphdb.properties > /opt/graphdb/home/conf/graphdb.properties
+
+              echo 'Configuring GraphDB cluster proxy hostnames'
+              echo "graphdb.hostname=$(hostname --fqdn)" >> /opt/graphdb/home/conf/graphdb.properties
+              echo "graphdb.rpc.address=$(hostname --fqdn):7300" >> /opt/graphdb/home/conf/graphdb.properties
+              echo "graphdb.vhosts=$(hostname --fqdn):7200, ${GRAPHDB_PUBLIC_URL}" >> /opt/graphdb/home/conf/graphdb.properties
+              echo "graphdb.external-url=${GRAPHDB_PUBLIC_URL}" >> /opt/graphdb/home/conf/graphdb.properties
+
+              echo 'Done'
+
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,8 +21,8 @@ images:
     repository: busybox
     tag: "1.36.1"
 
-# Extra labels for the deployed resources
-extraLabels: {}
+# Additional common labels for the deployed resources
+labels: {}
 
 ####### DEPLOYMENT CONFIGURATIONS #######
 deployment:

--- a/values.yaml
+++ b/values.yaml
@@ -323,3 +323,17 @@ graphdb:
     create: false
     minAvailable: "51%"
     maxUnavailable:
+
+  #
+  # Service account for the GraphDB nodes.
+  # GraphDB by itself has no need to communicate with the Kubernetes API but the service account tokens can be used
+  # as ODIC tokens for authentication in cloud APIs.
+  #
+  serviceAccount:
+    # - Specifies whether a service account should be created
+    create: true
+    # - The name of the service account to use.
+    # - If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # If create is true, add extra annotations to the created service account.
+    annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -21,8 +21,37 @@ images:
     repository: busybox
     tag: "1.36.1"
 
-# Additional common labels for the deployed resources
+# Overrides the name of the chart affecting the resources names for GraphDB
+# To override the GraphDB proxy's name, use proxy.nameOverride
+nameOverride: ""
+
+# Overrides the naming of all GraphDB resources, effectively removing the release name prefix. Takes precedence over nameOverride
+# To override the GraphDB proxy's full name, use proxy.fullnameOverride
+fullnameOverride: ""
+
+# Additional common labels to add to the resources
 labels: {}
+
+# Additional common annotations to add to the resources
+annotations: {}
+
+# Runtime configuration overrides
+configuration:
+  properties:
+    existingConfigmap: ""
+    configmapKey: "graphdb.properties"
+  logback:
+    existingConfigmap: ""
+    configmapKey: "logback.xml"
+
+# Initial provisioning overrides
+provision:
+  settings:
+    existingConfigmap: ""
+    configmapKey: "settings.js"
+  users:
+    existingConfigmap: ""
+    configmapKey: "users.js"
 
 ####### DEPLOYMENT CONFIGURATIONS #######
 deployment:
@@ -94,16 +123,8 @@ graphdb:
   # -- References to configuration maps containing settings.js, users.js, graphdb.properties, and logback.xml files to overwrite
   # the default GraphDB configuration. For reference see https://graphdb.ontotext.com/documentation/10.6/directories-and-config-properties.html
   configs:
-    # Override default settings configuration
-    #settingsConfigMap: graphdb-settings-configmap
-    # Override default users configuration
-    #usersConfigMap: graphdb-users-configmap
-    # Override default properties configuration
-    #propertiesConfigMap: graphdb-properties-configmap
-    # Override default logback configuration
-    #logbackConfigMap: graphdb-logback-configmap
     # Optional configmap containing repository configuration ttl file(s). GraphDB will automatically create repositories with the provided repositories configuration files
-    # provisionRepositoriesConfigMap: graphdb-repositories-configmap
+    provisionRepositoriesConfigMap: ""
 
   security:
     # If the security is enabled, it's mandatory to have a provisioning user, so the health-checks and cluster linking can work properly
@@ -337,3 +358,17 @@ graphdb:
     name: ""
     # If create is true, add extra annotations to the created service account.
     annotations: {}
+
+# Configurations for the GraphDB proxy
+proxy:
+  # Overrides the name of the GraphDB proxy component
+  nameOverride: ""
+
+  # Overrides the naming of all GraphDB proxy resources, effectively removing the release name prefix. Takes precedence over proxy.nameOverride
+  fullnameOverride: ""
+
+  # Additional common labels to add to the GraphDB proxy resources
+  labels: {}
+
+  # Additional common annotations to add to the GraphDB proxy resources
+  annotations: {}


### PR DESCRIPTION
Resource names are no longer hardcoded and are using the templates for `nameOverride` and `fullnameOverride`.

- Removed setting FQDN as hostnames in GraphDB and the proxy in favor of dynamically resolving and configuring the hostnames in the init containers
- Added GraphDB and GraphDB proxy hostnames resolution in the init containers
- GraphDB properties and logback configuration configmaps are now applied by default
- Added `annotations` for common annotations across resources
- Renamed `extraLabels` to just `labels`
- Values in `labels` and `annotations` are now evaluated as templates
- Added separate `labels` and `annotations` for the cluster proxy
- Renamed GraphDB storage PVC prefix to `graphdb-storage` and server import folder to `graphdb-server-import`
- Added service account configurations for the GraphDB pods
