### PR TITLE
Change from ingress class annotation to ingressClassName in spec

### DIFF
--- a/templates/gateway/ingress.yaml
+++ b/templates/gateway/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.deployment.ingress.class }}
     {{- if .Values.deployment.tls.enabled }}
     ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}
@@ -24,6 +23,7 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  ingressClassName: {{ .Values.deployment.ingress.class }}
   {{- if .Values.deployment.tls.enabled }}
   tls:
     - hosts:


### PR DESCRIPTION
This PR moves the ingress-class from the annotations to the spec section. Using the annotations was deprecated in k8s 1.18.

https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/