### PR TITLE
fix provisioning init container

### DIFF
--- a/templates/graphdb-node.yaml
+++ b/templates/graphdb-node.yaml
@@ -183,7 +183,7 @@ spec:
           {{- with .Values.graphdb.node.initContainerResources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
-          command: ['sh', '-c']
+          command: ['bash', '-c']
           args:
             - |
               set -eu


### PR DESCRIPTION
The test commands in the script require bash to be executed. However with `sh` they fail.
This is broken since 1.6.x helm charts. My guess, the busybox image changed the default shell.