### PR TITLE
GDB-10462: Updated cluster jobs to always use the temp folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # GraphDB Helm chart release notes
 
+## Version 11.0.1
+
+GraphDB Helm 11.0.1 is a patch release that includes bug fixes.
+
+### Fixed
+
+- Updated all cluster jobs to explicitly use `/tmp` as a working directory to avoid permission errors due to the default security
+  context's `readOnlyRootFilesystem` when the container has a starting folder different from `/tmp`.
+- Updated all utility scripts to use temporary files under `/tmp` for the same reason.
+
 ## Version 11.0.0
 
 Version 11 of the chart addresses a bunch of legacy issues and aims to provide much better user experience and reliability.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.0.0
+version: 11.0.1
 appVersion: 10.6.4
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Helm Chart for GraphDB
 
 [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml)
-![Version: 11.0.0](https://img.shields.io/badge/Version-11.0.0-informational?style=flat-square)
+![Version: 11.0.1](https://img.shields.io/badge/Version-11.0.1-informational?style=flat-square)
 ![AppVersion: 10.6.4](https://img.shields.io/badge/AppVersion-10.6.4-informational?style=flat-square)
 
 <!--

--- a/templates/graphdb/statefulset.yaml
+++ b/templates/graphdb/statefulset.yaml
@@ -225,6 +225,7 @@ spec:
           {{- with .Values.initContainerResources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
+          workingDir: /tmp
           command: [ "bash", "-c" ]
           args:
             - |

--- a/templates/jobs/job-create-cluster.yaml
+++ b/templates/jobs/job-create-cluster.yaml
@@ -66,6 +66,7 @@ spec:
             - name: cluster-config
               mountPath: /tmp/cluster-config/cluster-config.json
               subPath: {{ .Values.cluster.config.configmapKey }}
+          workingDir: /tmp
           command: ["bash"]
           args:
             - "/tmp/utils/graphdb.sh"

--- a/templates/jobs/job-patch-cluster.yaml
+++ b/templates/jobs/job-patch-cluster.yaml
@@ -70,6 +70,7 @@ spec:
             - name: cluster-config
               mountPath: /tmp/cluster-config/cluster-config.json
               subPath: {{ .Values.cluster.config.configmapKey }}
+          workingDir: /tmp
           command: ["bash"]
           args:
             - "/tmp/utils/update-cluster.sh"

--- a/templates/jobs/job-provision-repositories.yaml
+++ b/templates/jobs/job-provision-repositories.yaml
@@ -65,6 +65,7 @@ spec:
               mountPath: /tmp/utils
             - name: repositories-config
               mountPath: /tmp/repositories-config
+          workingDir: /tmp
           command: ["bash"]
           args:
             - "/tmp/utils/graphdb.sh"

--- a/templates/jobs/job-scale-down-cluster.yaml
+++ b/templates/jobs/job-scale-down-cluster.yaml
@@ -65,6 +65,7 @@ spec:
               mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
+          workingDir: /tmp
           command: ["bash"]
           args:
             - "/tmp/utils/update-cluster.sh"

--- a/templates/jobs/job-scale-up-cluster.yaml
+++ b/templates/jobs/job-scale-up-cluster.yaml
@@ -66,6 +66,7 @@ spec:
               mountPath: /tmp
             - name: graphdb-utils
               mountPath: /tmp/utils
+          workingDir: /tmp
           command: ["bash"]
           args:
             - "/tmp/utils/update-cluster.sh"

--- a/templates/proxy/statefulset.yaml
+++ b/templates/proxy/statefulset.yaml
@@ -183,6 +183,7 @@ spec:
               mountPath: /tmp/graphdb/graphdb-extra-secret.properties
               subPath: {{ .Values.proxy.configuration.extraProperties.secretKey }}
             {{- end }}
+          workingDir: /tmp
           command: [ "bash", "-c" ]
           args:
             - |


### PR DESCRIPTION
Changes:

- Updated all cluster jobs to explicitly use `/tmp` as a working directory to avoid permission errors due to the default security context's `readOnlyRootFilesystem` when the container has a starting folder different from `/tmp`.
- Updated all utility scripts to use temporary files under `/tmp` for the same reason.
- Prepared for version 11.0.1