### PR TITLE
[GDB-10412] Add examples for deploying GraphDB in Azure

### DIFF
--- a/examples/aws/ingress/README.md
+++ b/examples/aws/ingress/README.md
@@ -17,4 +17,8 @@ This document describes the steps on how to configure the GraphDB Helm chart to 
 
 ## Note
 
-After you deploy and the ingress is created please change the externalUrl value to the DNS name of the ALB or Route53.
+After you deploy the GraphDB chart you should either point an DNS name to the ALB and set
+the externalUrl property in the chart and re-apply it, or the other option you can use nip.io and map it's
+public ip address to nip.io. In order to do that use the kubectl get ingress commands and copy the Public IP
+for the GraphDB ingress, then go to the values file and set the externalUrl property to http://ip.address.nip.io/.
+Otherwise Workbench won't be accessible.

--- a/examples/aws/ingress/values.yaml
+++ b/examples/aws/ingress/values.yaml
@@ -1,7 +1,9 @@
 # This example shows how to deploy and expose GraphDB with AWS Load Balancer Controller Ingress without SSL.
 
 configuration:
-  externalUrl: http://graphdb-example-dns-name.com/ # Change this to your ALB DNS name or Route53 if you use it.
+  # Change this to your Route53 domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the AWS Load Balancer to the nip.io.
+  externalUrl: http://ip.address.nip.io/
 
 ingress:
   enabled: true
@@ -9,6 +11,8 @@ ingress:
   annotations:
    alb.ingress.kubernetes.io/load-balancer-name: graphdb-ingress
    alb.ingress.kubernetes.io/target-type: ip
+   # This ensures the load balancer is public
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/inbound-cidrs: "0.0.0.0/0"
+   # Define the ports on which the Ingress should create listener
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'

--- a/examples/aws/ingress/values_https.yaml
+++ b/examples/aws/ingress/values_https.yaml
@@ -1,7 +1,9 @@
 # This example shows how to deploy and expose GraphDB with AWS Load Balancer Controller Ingress with SSL enabled.
 
 configuration:
-  externalUrl: https://graphdb-example-dns-name.com/ # Change this to your ALB DNS name or Route53 if you use it.
+  # Change this to your Route53 domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the AWS Load Balancer to the nip.io.
+  externalUrl: https://ip.address.nip.io
 
 ingress:
   enabled: true
@@ -9,9 +11,13 @@ ingress:
   annotations:
    alb.ingress.kubernetes.io/load-balancer-name: graphdb-ingress
    alb.ingress.kubernetes.io/target-type: ip
+   # This ensures the load balancer is public
    alb.ingress.kubernetes.io/scheme: internet-facing
    alb.ingress.kubernetes.io/inbound-cidrs: "0.0.0.0/0"
+   # Define the ports on which the Ingress should create listener
    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-   alb.ingress.kubernetes.io/certificate-arn: "" # ARN of the ACM SSL Certificate that will be used
+   # ARN of the ACM SSL Certificate that will be used
+   alb.ingress.kubernetes.io/certificate-arn: ""
    alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
+   # Enable SSL redirect on the listener
    alb.ingress.kubernetes.io/ssl-redirect: '443'

--- a/examples/aws/lb-example/README.md
+++ b/examples/aws/lb-example/README.md
@@ -11,4 +11,4 @@ This folder contains examples of using GraphDB with the AWS Network Load Balance
 ## Example
 
 * [values.yaml](values.yaml) - Example of how to deploy and expose GraphDB with Network Load Balancer without SSL enabled.
-* [values_https.yaml] - Example of how to deploy and expose GraphDB with Network Load Balancer with SSL enabled.
+* [values_https.yaml](values_https.yaml) - Example of how to deploy and expose GraphDB with Network Load Balancer with SSL enabled.

--- a/examples/aws/lb-example/values.yaml
+++ b/examples/aws/lb-example/values.yaml
@@ -10,5 +10,6 @@ service:
    service.beta.kubernetes.io/aws-load-balancer-name: "graphdb-lb"
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-   service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"  # This ensures the load balancer is internet-facing
+   # This ensures the load balancer is public
+   service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
    service.beta.kubernetes.io/load-balancer-source-ranges: "0.0.0.0/0"

--- a/examples/aws/lb-example/values_https.yaml
+++ b/examples/aws/lb-example/values_https.yaml
@@ -10,8 +10,10 @@ service:
    service.beta.kubernetes.io/aws-load-balancer-name: "graphdb-lb"
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-   service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"  # This ensures the load balancer is internet-facing
+    # This ensures the load balancer is public
+   service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
    service.beta.kubernetes.io/load-balancer-source-ranges: "0.0.0.0/0"
-   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "" # ARN of the ACM SSL Certificate that will be used
-   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443" # Ports to be used for the SSL
+    # ARN of the ACM SSL Certificate that will be used
+   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: ""
+   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
    service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"

--- a/examples/aws/service-account/README.md
+++ b/examples/aws/service-account/README.md
@@ -2,7 +2,8 @@
 
 This folder contains examples of using GraphDB with the Service account to gain access to the AWS services.
 
-The main reason that we want to use service accounts is that GraphDB relies on S3 for the Cloud Backups. But you can use that service account to use other AWS services from the EKS cluster as well, 
+The main reason that we want to use service accounts is that GraphDB relies on S3 for the Cloud Backups. 
+But you can use that service account to use other AWS services from the EKS cluster as well, 
 when you have configured your IAM policies properly.
 
 ## Pre-requisites
@@ -15,4 +16,3 @@ when you have configured your IAM policies properly.
 ## Example
 
 * [values.yaml](values.yaml) - Example of how to deploy the service account.
-

--- a/examples/aws/service-account/values.yaml
+++ b/examples/aws/service-account/values.yaml
@@ -1,5 +1,5 @@
 serviceAccount:
   create: true
-  name: graphdb
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/eks-service-account-role # Example ARN Role, replace with your actual IAM Role ARN
+    # Example ARN Role, replace with your actual IAM Role ARN
+    eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/eks-service-account-role

--- a/examples/azure/ingress/README.md
+++ b/examples/azure/ingress/README.md
@@ -1,0 +1,22 @@
+# AKS Application Gateway Ingress deployment
+
+This document describes the steps on how to configure the GraphDB Helm chart to use Application Gateway Ingress on Azure AKS.
+
+## Prerequisites
+
+* AKS Cluster: Ensure you have an AKS cluster up and running.
+* [Enable application gateway ingress on existing AKS cluster](https://learn.microsoft.com/en-us/azure/application-gateway/tutorial-ingress-controller-add-on-new)
+* [Application Gateway supported annotations](https://azure.github.io/application-gateway-kubernetes-ingress/annotations/)
+
+## Example
+
+* [values.yaml](values.yaml) - Example of how to deploy and expose GraphDB with Ingress without SSL enabled.
+* [values_https.yaml](values_https.yaml) - Example of how to deploy and expose GraphDB with Ingress with SSL enabled.
+
+## Note
+
+After you deploy the GraphDB chart you should either point an DNS name to the Application Gateway and set 
+the externalUrl property in the chart and re-apply it, or the other option you can use nip.io and map it's 
+public ip address to nip.io. In order to do that use the kubectl get ingress commands and copy the Public IP 
+for the GraphDB ingress, then go to the values file and set the externalUrl property to http://ip.address.nip.io/. 
+Otherwise Workbench won't be accessible.

--- a/examples/azure/ingress/values.yaml
+++ b/examples/azure/ingress/values.yaml
@@ -1,0 +1,10 @@
+# This example shows how to deploy and expose GraphDB with Application Gateway Ingress without SSL.
+
+configuration:
+  # Change this to your AzureDNS domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the Application Gateway to the nip.io.
+  externalUrl: http://ip.address.nip.io/
+
+ingress:
+  enabled: true
+  className: azure-application-gateway

--- a/examples/azure/ingress/values_https.yaml
+++ b/examples/azure/ingress/values_https.yaml
@@ -1,0 +1,15 @@
+# This example shows how to deploy and expose GraphDB with Application Gateway Ingress with SSL certificate hosted in the KeyVault Service.
+
+configuration:
+  # Change this to your AzureDNS domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the Application Gateway to the nip.io.
+  externalUrl: https://ip.address.nip.io/
+
+ingress:
+  enabled: true
+  className: azure-application-gateway
+  annotations:
+    # Set the name of the SSL certificate that you have in the KeyVault Service
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: "name-of-appgw-installed-certificate"
+    # Enable SSL redirect on the listener
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"

--- a/examples/azure/lb-example/README.md
+++ b/examples/azure/lb-example/README.md
@@ -1,0 +1,14 @@
+# AKS Load Balancer type deployment
+
+This folder contains examples of using GraphDB with the Azure Load Balancer.
+
+## Pre-requisites 
+
+* AKS Cluster: Ensure you have an AKS cluster up and running.
+* [Use a public standard load balancer in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/load-balancer-standard)
+* [Expose an AKS service over HTTP or HTTPS using Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-expose-service-over-http-https)
+* [Azure Kubernetes Service Type Load Balancer supported annotations](https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#loadbalancer-annotations)
+
+## Example
+
+* [values.yaml](values.yaml) - Example of how to deploy and expose GraphDB with Azure Load Balancer.

--- a/examples/azure/lb-example/values.yaml
+++ b/examples/azure/lb-example/values.yaml
@@ -1,0 +1,9 @@
+# This example shows how to deploy and expose GraphDB with Service Type Load Balancer without SSL enabled.
+
+service:
+  enabled: true
+  ports:
+   http: 80
+  type: LoadBalancer
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "false"

--- a/examples/azure/service-account/README.md
+++ b/examples/azure/service-account/README.md
@@ -1,0 +1,21 @@
+# Azure Service Account Examples
+
+This folder contains examples of using GraphDB with the Service account to gain access to the Azure services.
+
+The main reason that we want to use service accounts is that GraphDB relies on Azure Storage Account 
+for the Cloud Backups. But you can use that service account to use other Azure services from the AKS cluster as well,
+when you have configured your IAM Role Assignments properly.
+
+## Pre-requisites
+
+* AKS Cluster: Ensure you have an AKS cluster up and running.
+* Before starting with the service account setup you should have an IAM Role assignment that should 
+  have access to the Azure Storage Account Service.
+* [Best practices for authentication and authorization in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/operator-best-practices-identity)
+* [Azure Login using identity](https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli-managed-identity)
+* [Deploy and configure workload identity on an Azure Kubernetes Service (AKS) cluster](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster)
+* [Azure Role Assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal)
+
+## Example
+
+* [values.yaml](values.yaml) - Example of how to deploy the service account.

--- a/examples/azure/service-account/values.yaml
+++ b/examples/azure/service-account/values.yaml
@@ -1,0 +1,4 @@
+serviceAccount:
+  create: true
+  annotations:
+    azure.workload.identity/client-id: <YOUR_MANAGED_IDENTITIY_CLIENT_ID>


### PR DESCRIPTION
- Added support for using Service Account with Azure Workload Identity
- Added support for using Application Gateway Ingress 
- Added support for using Service type LoadBalancer with Application Gateway Ingress in order to provide SSL.