### PR TITLE
GDB-10521: Set the containers workdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
       with `backup.cloud`
     - Added a new example under [examples/backup-local](examples/backup-local) showing how to use the local backup feature
 
+### Fixed
+
+- Updated the GraphDB containers to explicitly use `/tmp` as a working directory to avoid permission errors due to the
+  default security context's `readOnlyRootFilesystem` when the container has a starting folder different from `/tmp`.
+
 ## Version 11.1.2
 
 ### New 

--- a/templates/graphdb/statefulset.yaml
+++ b/templates/graphdb/statefulset.yaml
@@ -313,6 +313,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ include "graphdb.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: /tmp
           {{- with .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/templates/proxy/statefulset.yaml
+++ b/templates/proxy/statefulset.yaml
@@ -262,6 +262,7 @@ spec:
         - name: {{ include "graphdb-proxy.chartName" . }}
           image: {{ include "graphdb.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: /tmp
           {{- if .Values.proxy.command }}
           command: {{ toYaml .Values.proxy.command | nindent 12 }}
           {{- else }}


### PR DESCRIPTION
Updated the GraphDB containers to explicitly use `/tmp` as a working directory to avoid permission errors due to the  default security context's `readOnlyRootFilesystem` when the container has a starting folder different from `/tmp`.
