### PR TITLE
Added examples for deploying GraphDB's Helm chart in GKE

### DIFF
--- a/examples/gcp/ingress/README.md
+++ b/examples/gcp/ingress/README.md
@@ -1,0 +1,23 @@
+# Overview
+
+This document describes the steps on how to configure the GraphDB Helm chart to use Ingress on GCP GKE.
+
+## Prerequisites
+
+* GKE Cluster: Ensure you have a GKE cluster up and running.
+* [Ingress Behaviour](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#controller_summary)
+* [Ingress Setup](https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer)
+* [Ingress Setup with SSL enabled using Google-managed certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs#creating_an_ingress_with_a_google-managed_certificate)
+
+## Example
+
+* [values.yaml](values.yaml) - Example of how to deploy and expose GraphDB with Ingress without SSL enabled.
+* [values_https.yaml](values_https.yaml) - Example of how to deploy and expose GraphDB with Ingress with SSL enabled.
+
+## Note
+
+After you deploy the GraphDB chart you should either point a DNS name to the Google Ingress and set
+the externalUrl property in the chart and re-apply it, or the other option you can use nip.io and map it's
+public ip address to nip.io. In order to do that use the kubectl get ingress commands and copy the Public IP
+for the GraphDB ingress, then go to the values file and set the externalUrl property to http://ip.address.nip.io/.
+Otherwise Workbench won't be accessible.

--- a/examples/gcp/ingress/values.yaml
+++ b/examples/gcp/ingress/values.yaml
@@ -1,0 +1,12 @@
+# This example shows how to deploy and expose GraphDB with GCP Load Balancer Controller Ingress without SSL.
+
+configuration:
+  # Change this to your Google Domains domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the GCP Ingress to the nip.io.
+  externalUrl: http://ip.address.nip.io/
+ingress:
+  enabled: true
+  annotations:
+    # This line could be omitted as GKE controller processes any Ingress that does not have
+    # the annotation kubernetes.io/ingress.class, or has the annotation with the value gce
+    kubernetes.io/ingress.class: gce

--- a/examples/gcp/ingress/values_https.yaml
+++ b/examples/gcp/ingress/values_https.yaml
@@ -1,0 +1,17 @@
+# This example shows how to deploy and expose GraphDB with GCP Load Balancer Controller Ingress with SSL enabled.
+
+configuration:
+  # Change this to your Google Domains domain name or use nip.io which you can do after you deploy the chart since you
+  # need to map the public IP address of the GCP Ingress to the nip.io.
+  externalUrl: https://ip.address.nip.io/
+ingress:
+  enabled: true
+  className: gce
+  annotations:
+    # This line could be omitted as GKE controller processes any Ingress that does not have
+    # the annotation kubernetes.io/ingress.class, or has the annotation with the value gce
+    kubernetes.io/ingress.class: gce
+    # Defines the name of the static IP address which the Ingress should use
+    kubernetes.io/ingress.global-static-ip-name: ""
+    # ManagedCertificate object which contains the domains for the SSL certificate
+    networking.gke.io/managed-certificates: ""

--- a/examples/gcp/lb-example/README.md
+++ b/examples/gcp/lb-example/README.md
@@ -1,0 +1,12 @@
+# GKE Load Balancer Type Deployment
+
+This folder contains examples of using GraphDB with the GCP Application Load Balancer.
+
+## Pre-requisites
+
+* EKS Cluster: Ensure you have an EKS cluster up and running.
+* [GCP Application Load Balancer Overview](https://cloud.google.com/load-balancing/docs/https)
+
+## Example
+
+* [values.yaml](values.yaml) - Example of how to deploy and expose GraphDB with External Application Load Balancer.

--- a/examples/gcp/lb-example/values.yaml
+++ b/examples/gcp/lb-example/values.yaml
@@ -1,0 +1,5 @@
+# This example shows how to deploy and expose GraphDB with External Application Load Balancer.
+
+service:
+  enabled: true
+  type: LoadBalancer


### PR DESCRIPTION
Added examples for exposing GraphDB via Ingress and via Service of LoadBalancer type.