### PR TITLE
GDB-10532: Added configuration examples for extra GraphDB plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Cloud backups support uploading the GraphDB backup archives in one of the supported cloud object storage services, configured with `backup.cloud`
     - Added a new example under [examples/backup-local](examples/backup-local) showing how to use the local backup feature with `backup.local`
 - Added a new property `security.provisioner.passwordHash` to define an initial password for the provisioner user as a bcrypt hash.
+- Configured `graphdb.extra.plugins` to load plugins from `/opt/graphdb/home/extra-plugins` by default
 
 ### Fixed
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,49 @@
+# GraphDB External Plugins Examples
+
+This folder contains examples of how to configure GraphDB with external plugins by providing them to the classpath.
+See https://graphdb.ontotext.com/documentation/10.7/plug-in-api.html#adding-external-plugins-to-graphdb for more information and
+configuration examples.
+
+## Using GraphDB Persistence
+
+For GraphDB to pick up and use external plugins, their JAR files must be registered in the classpath.
+The Helm chart configures GraphDB to expect extra plugins at `/opt/graphdb/home/extra-plugins` from where the database will pick them up.
+
+The directory `/opt/graphdb/home/extra-plugins` is located inside the default persistence volume.
+Any extra plugins that have been provisioned in this directory will be available between pod restarts and GraphDB updates.
+
+There are two common ways to provide extra plugins inside existing PV:
+
+* Using a custom init container that will download JARs from the internet or from other locations.
+* Copying the files manually using `kubectl` from your local system or copying them from another PV.
+
+This example will focus on copying JAR files with `kubectl`.
+
+For example, to configure GraphDB with an external plugin inside the GraphDB pod `graphdb-0`, you can use:
+
+```bash
+kubectl cp custom-plugin.jar graphdb-0:/opt/graphdb/home/extra-plugins/
+```
+
+In case of a GraphDB cluster setup, you have to provide the plugin to all pods:
+
+```bash
+kubectl cp custom-plugin.jar graphdb-0:/opt/graphdb/home/extra-plugins/
+kubectl cp custom-plugin.jar graphdb-1:/opt/graphdb/home/extra-plugins/
+kubectl cp custom-plugin.jar graphdb-2:/opt/graphdb/home/extra-plugins/
+```
+
+## Using Another Persistence Volume
+
+Another option is to prepare a different PVC and PV, copy the plugins inside that PV and configure GraphDB to use it with:
+
+```yaml
+extraVolumes:
+  - name: extra-plugins
+    persistentVolumeClaim:
+      claimName: graphdb-extra-plugins
+
+extraVolumeMounts:
+  - name: extra-plugins
+    mountPath: /opt/graphdb/home/extra-plugins
+```

--- a/templates/graphdb/configmap-properties.yaml
+++ b/templates/graphdb/configmap-properties.yaml
@@ -17,6 +17,7 @@ data:
     graphdb.append.request.id.headers=true
     graphdb.workbench.importDirectory=/opt/graphdb/home/graphdb-import
     graphdb.ontop.jdbc.path=/opt/graphdb/home/jdbc-driver
+    graphdb.extra.plugins=/opt/graphdb/home/extra-plugins
     {{- if eq (int .Values.replicas) 1}}
     graphdb.external-url={{ include "graphdb.external-url" . }}
     {{- end }}


### PR DESCRIPTION
The examples describe how to provide plugin JARs to GraphDB's classpath in two different ways, one of which is by copying them with `kubectl`.

Added short description for a third option that includes an existing PV.

Configured `graphdb.extra.plugins` to load plugins from `/opt/graphdb/home/extra-plugins` by default.