### PR TITLE
GDB-10777 Fix backup examples

### DIFF
--- a/examples/aws/backup/README.md
+++ b/examples/aws/backup/README.md
@@ -75,7 +75,7 @@ ServiceAccount to an IAM role:
 backup:
   enabled: true
   type: cloud
-  schedule: @midnight
+  schedule: "@midnight"
   cloud:
     bucketUri: s3:///<bucket>/${BACKUP_NAME}?region=<region>
 serviceAccount:

--- a/examples/azure/backup/README.md
+++ b/examples/azure/backup/README.md
@@ -73,7 +73,7 @@ the ServiceAccount to a Managed Identity:
 backup:
   enabled: true
   type: cloud
-  schedule: @midnight
+  schedule: "@midnight"
   cloud:
     bucketUri: az://<storage_container>/${BACKUP_NAME}?blob_storage_account=<storage_account>
 serviceAccount:


### PR DESCRIPTION
Fix Helm throwing error (`found character that cannot start any token`) when `@midnight` is not quoted when used (mentioned in AWS and Azure backups examples).