### PR TITLE
GDB-8948: Improved ArgoCD compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 11.3.0
+
+### Updated
+
+- Removed any pre-install, pre-upgrade, pre-rollback Helm hooks annotations to allow seamless ArgoCD deployments.
+
 ## Version 11.2.2
 
 ### New

--- a/templates/jobs/configmap-utils.yaml
+++ b/templates/jobs/configmap-utils.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback, post-install, post-upgrade, post-rollback
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     {{- if .Values.backup.enabled }}
     "helm.sh/hook-delete-policy": before-hook-creation
     {{- else }}

--- a/templates/jobs/job-scale-down-cluster.yaml
+++ b/templates/jobs/job-scale-down-cluster.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-upgrade, pre-rollback
+    "helm.sh/hook": post-upgrade, post-rollback
     "helm.sh/hook-delete-policy": before-hook-creation, hook-succeeded, hook-failed
     {{- with .Values.annotations }}
       {{- tpl (toYaml .) $ | nindent 4 }}

--- a/templates/jobs/secret-provision-user.yaml
+++ b/templates/jobs/secret-provision-user.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "graphdb.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install, pre-upgrade, pre-rollback, post-install, post-upgrade, post-rollback
+    "helm.sh/hook": post-install, post-upgrade, post-rollback
     {{- if .Values.backup.enabled }}
     "helm.sh/hook-delete-policy": before-hook-creation
     {{- else }}


### PR DESCRIPTION
Removed any pre-install, pre-upgrade, pre-rollback Helm hooks annotations to allow seamless ArgoCD deployments. 

Such hooks were used in:

- configmap-utils.yaml
- secret-provision-user.yaml
- job-scale-down-cluster.yaml