### PR TITLE
GDB-11366: Release GraphDB 10.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 11.3.2
+
+### New
+
+- Updated to GraphDB [10.8.2](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-2)
+
 ## Version 11.3.1
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.3.1
-appVersion: 10.8.1
+version: 11.3.2
+appVersion: 10.8.2
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helm Chart for GraphDB
 
 [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml)
-![Version: 11.3.1](https://img.shields.io/badge/Version-11.3.1-informational?style=flat-square)
-![AppVersion: 10.8.1](https://img.shields.io/badge/AppVersion-10.8.1-informational?style=flat-square)
+![Version: 11.3.2](https://img.shields.io/badge/Version-11.3.2-informational?style=flat-square)
+![AppVersion: 10.8.2](https://img.shields.io/badge/AppVersion-10.8.2-informational?style=flat-square)
 
 <!--
 TODO: Add ArtifactHub badge when ready


### PR DESCRIPTION
- Increased the GraphDB version to 10.8.2
- Increased the Helm chart version to 11.3.2