### PR TITLE
Added example for configuring GraphDB Tomcat SSL/TLS.

### DIFF
--- a/examples/tomcat-security/README.md
+++ b/examples/tomcat-security/README.md
@@ -1,0 +1,39 @@
+Configuring Tomcat server with SSL/TLS
+===
+
+This guide provides instructions for configuring the embedded GraphDB Tomcat server with SSL/TLS.
+There are 3 scenarios for configuring the security of the GraphDB instance:
+- By providing a keystore.
+- By providing keystore and truststore - used to configure mTLS.
+- By providing a truststore - used in cases where GraphDB should trust an external service.
+
+**Note**
+If the Tomcat server is configured with SSL/TLS it will also configure the cluster gRPC communication SSL/TLS.
+
+### See more about Tomcat TLS/SSL set up:
+- GraphDB official documentation: https://graphdb.ontotext.com/documentation/10.8/encryption.html#configuring-graphdb-instance-with-ssl
+- Tomcat documentation: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html
+- Troubleshooting: https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html#Troubleshooting
+
+## Configuring using keystore and truststore 
+
+**Prerequisites:**
+* Certificate and certificate private key in PEM format.
+* Keystore that contains both the private key and certificate.
+* Truststore that contains the certificate to be trusted or the CA.
+
+[Configuration example](keystoreAndTruststore.yaml)
+
+## Configuring using keystore
+
+**Prerequisites:**
+* Keystore that contains both the private key and certificate.
+
+[Configuration example](keystore.yaml)
+
+## Configuring using truststore
+
+**Prerequisites:**
+* Truststore that contains the certificate to be trusted or the CA.
+
+[Configuration example](truststore.yaml)

--- a/examples/tomcat-security/keystore.yaml
+++ b/examples/tomcat-security/keystore.yaml
@@ -1,0 +1,28 @@
+configuration:
+  tls:
+    keystore:
+      existingSecret: my-keystore-secret
+      keystoreKey: keystore.jks
+      keystorePasswordKey: keystore_password
+      keyAlias: graphdb
+    # The path where the TLS files will be mounted inside the container.
+    mountPath: /etc/graphdb/tls/tomcat/
+startupProbe:
+  httpGet:
+    scheme: HTTPS
+readinessProbe:
+  httpGet:
+    scheme: HTTPS
+livenessProbe:
+  httpGet:
+    scheme: HTTPS
+proxy:
+  startupProbe:
+    httpGet:
+      scheme: HTTPS
+  readinessProbe:
+    httpGet:
+      scheme: HTTPS
+  livenessProbe:
+    httpGet:
+      scheme: HTTPS

--- a/examples/tomcat-security/keystoreAndTruststore.yaml
+++ b/examples/tomcat-security/keystoreAndTruststore.yaml
@@ -1,0 +1,32 @@
+configuration:
+  tls:
+    keystore:
+      existingSecret: my-keystore-secret
+      keystoreKey: keystore.jks
+      keystorePasswordKey: keystore_password
+      keyAlias: graphdb
+    truststore:
+      existingSecret: my-truststore-secret
+      truststoreKey: truststore.jks
+      truststorePasswordKey: truststore_password
+    # The path where the TLS files will be mounted inside the container.
+    mountPath: /etc/graphdb/tls/tomcat/
+startupProbe:
+  httpGet:
+    scheme: HTTPS
+readinessProbe:
+  httpGet:
+    scheme: HTTPS
+livenessProbe:
+  httpGet:
+    scheme: HTTPS
+proxy:
+  startupProbe:
+    httpGet:
+      scheme: HTTPS
+  readinessProbe:
+    httpGet:
+      scheme: HTTPS
+  livenessProbe:
+    httpGet:
+      scheme: HTTPS

--- a/examples/tomcat-security/truststore.yaml
+++ b/examples/tomcat-security/truststore.yaml
@@ -1,0 +1,8 @@
+configuration:
+  tls:
+    truststore:
+      existingSecret: my-truststore-secret
+      truststoreKey: truststore.jks
+      truststorePasswordKey: truststore_password
+    # The path where the TLS files will be mounted inside the container.
+    mountPath: /etc/graphdb/tls/tomcat/


### PR DESCRIPTION
Created a description and values.yaml files that show all the ways to set up the GraphDB Tomcat SSL/TLS .