### PR TITLE
Add service account to backup job

### DIFF
--- a/templates/jobs/cronjob-backup.yaml
+++ b/templates/jobs/cronjob-backup.yaml
@@ -22,7 +22,8 @@ spec:
       template:
         spec:
           restartPolicy: Never
-          automountServiceAccountToken: false
+          serviceAccountName: {{ include "graphdb.serviceAccountName" . }}
+          automountServiceAccountToken: true
           {{- if .Values.jobs.schedulerName }}
           schedulerName: {{ .Values.jobs.schedulerName }}
           {{- end }}


### PR DESCRIPTION
I suggest to add the Kubernetes Service Account to the backup job, allowing to grant access to external object storage like S3 or GCS using IRSA or Workload Identity for example.

Let me know if you prefer this to be optional.