### PR TITLE
GDB-11494: Avoid rendering GraphDB properties in quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GraphDB Helm chart release notes
 
+## Version 11.3.3
+
+### Fixed
+
+- Removed `| quote` from rendering `configuration.properties` in properties ConfigMaps in order to allow configuring GraphDB with
+  non-string properties.
+
 ## Version 11.3.2
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.3.2
+version: 11.3.3
 appVersion: 10.8.2
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Helm Chart for GraphDB
 
 [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml)
-![Version: 11.3.2](https://img.shields.io/badge/Version-11.3.2-informational?style=flat-square)
+![Version: 11.3.3](https://img.shields.io/badge/Version-11.3.3-informational?style=flat-square)
 ![AppVersion: 10.8.2](https://img.shields.io/badge/AppVersion-10.8.2-informational?style=flat-square)
 
 <!--

--- a/templates/graphdb/configmap-properties.yaml
+++ b/templates/graphdb/configmap-properties.yaml
@@ -28,7 +28,7 @@ data:
     ##### Overrides from values.yaml #####
     {{- range $key, $val := .Values.configuration.properties -}}
     {{- if ne $val nil }}
-    {{ $key }}={{ tpl ($val | toString) $ | quote }}
+    {{ $key }}={{ tpl ($val | toString) $ }}
     {{- end }}
     {{- end -}}
     {{- end -}}

--- a/templates/proxy/configmap-properties.yaml
+++ b/templates/proxy/configmap-properties.yaml
@@ -20,7 +20,7 @@ data:
     ##### Overrides from values.yaml #####
     {{- range $key, $val := .Values.proxy.configuration.properties -}}
     {{- if ne $val nil }}
-    {{ $key }}={{ tpl ($val | toString) $ | quote }}
+    {{ $key }}={{ tpl ($val | toString) $ }}
     {{- end }}
     {{- end -}}
     {{- end -}}


### PR DESCRIPTION
The config maps for both GraphDB and the cluster proxy were rendering all values from `configuration.properties` in quotes which is problematic because some properties are expected as non-strings.

Removed `| quote` to allow non-string values such as booleans and numbers.

Prepared Helm release v11.3.3