### PR TITLE
GDB-11193: Time zone configurations for the backup cron job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # GraphDB Helm chart release notes
 
+## Version 11.4.0
+
+### New
+
+- Added new configuration properties for GraphDB Tomcat connector SSL/TLS
+  - Added `configuration.tls.keystore` to configure a keystore with its properties
+  - Added `configuration.tls.truststore` to configure a truststore with its properties
+  - Added `configuration.tls.certificateRevocationList` to configure a certificate revocation list
+- Added new configuration properties for configuring GraphDB cluster security (SSL/TLS)
+  - Added `cluster.tls.mode` to configure cluster security mode
+  - Added `cluster.tls.keystore` to configure a keystore with its properties
+  - Added `cluster.tls.truststore` to configure a truststore with its properties
+  - Added `cluster.tls.certificate` to configure a certificate
+  - Added `cluster.tls.certificateChain` to configure a certificate chain
+  - Added `cluster.tls.certificateKey` to configure a private key with its properties
+  - Added `cluster.tls.rootCerts` to configure root certificates to be trusted
+  - Added `cluster.tls.certificateRevocationList` to configure a certificate revocation list
+- Updated jobs and scripts to use `https` or `http` depending on whether the Tomcat connector security is configured
+- Added `indices` configuration enabling a job for initial preloading of indices and other SPARQL updates
+
 ## Version 11.3.3
 
 ### Fixed
@@ -27,21 +47,6 @@
   - Added `license.mountPath` to configure where the license volume is mounted
   - Added `license.optional` to configure the license volume as optional if needed
   - Added `license.readOnly` to configure the read/write mode of the license volume mount
-- Added new configuration properties for GraphDB Tomcat connector SSL/TLS
-  - Added `configuration.tls.keystore` to configure a keystore with its properties
-  - Added `configuration.tls.truststore` to configure a truststore with its properties
-  - Added `configuration.tls.certificateRevocationList` to configure a certificate revocation list
-- Added new configuration properties for configuring GraphDB cluster security (SSL/TLS)
-  - Added `cluster.tls.mode` to configure cluster security mode
-  - Added `cluster.tls.keystore` to configure a keystore with its properties
-  - Added `cluster.tls.truststore` to configure a truststore with its properties
-  - Added `cluster.tls.certificate` to configure a certificate
-  - Added `cluster.tls.certificateChain` to configure a certificate chain
-  - Added `cluster.tls.certificateKey` to configure a private key with its properties
-  - Added `cluster.tls.rootCerts` to configure root certificates to be trusted
-  - Added `cluster.tls.certificateRevocationList` to configure a certificate revocation list
-- Updated jobs and scripts to use `https` or `http` depending on whether the Tomcat connector security is configured
-
 - Updated to GraphDB [10.8.0](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-0)
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Added `cluster.tls.certificateRevocationList` to configure a certificate revocation list
 - Updated jobs and scripts to use `https` or `http` depending on whether the Tomcat connector security is configured
 - Added `indices` configuration enabling a job for initial preloading of indices and other SPARQL updates
+- Added `backup.timezone` configuration for overriding the default timezone with a specific one
 
 ## Version 11.3.3
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.3.3
+version: 11.4.0
 appVersion: 10.8.2
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/

--- a/templates/jobs/cronjob-backup.yaml
+++ b/templates/jobs/cronjob-backup.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   schedule: {{ .Values.backup.schedule | quote }}
+  {{- if and .Values.backup.timezone (semverCompare ">=1.27-0" .Capabilities.KubeVersion.Version) }}
+  timeZone: {{ .Values.backup.timezone }}
+  {{- end }}
   successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
   concurrencyPolicy: Forbid

--- a/values.yaml
+++ b/values.yaml
@@ -756,6 +756,12 @@ backup:
   # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
   schedule: "@midnight"
 
+  # Specifies the time zone for the cron job. If not specified, Kubernetes will use the local time zone by default.
+  # This requires Kubernetes v1.27 or greater.
+  #
+  # Ref: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  timezone: ""
+
   # Backup options that will be injected as JSON in the default backup options Secret. \
   # These configurations define the backup behaviour such as including or excluding repositories or system data.
   #


### PR DESCRIPTION
Added a new configuration that allows to override the default timezone which usually is the local timezone.

Bump the chart to version 11.4.0

* Fixed the changelog for version 11.4.0 as some entries were for 11.3.0 which is already released