### PR TITLE
GDB-11527: Update to GraphDB 10.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 11.3.4
+
+### New
+
+- Updated to GraphDB [10.8.3](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-3)
+
 ## Version 11.3.3
 
 ### Fixed

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.3.3
-appVersion: 10.8.2
+version: 11.3.4
+appVersion: 10.8.3
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helm Chart for GraphDB
 
 [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml)
-![Version: 11.3.3](https://img.shields.io/badge/Version-11.3.3-informational?style=flat-square)
-![AppVersion: 10.8.2](https://img.shields.io/badge/AppVersion-10.8.2-informational?style=flat-square)
+![Version: 11.3.4](https://img.shields.io/badge/Version-11.3.4-informational?style=flat-square)
+![AppVersion: 10.8.3](https://img.shields.io/badge/AppVersion-10.8.3-informational?style=flat-square)
 
 <!--
 TODO: Add ArtifactHub badge when ready


### PR DESCRIPTION
- Updated the Helm chart to use GraphDB version 10.8.3
- Updated the Helm chart to version 11.3.4