### PR TITLE
Added comments indicating that if a CA is used to sign the certificat…

### DIFF
--- a/examples/grpc-security/README.md
+++ b/examples/grpc-security/README.md
@@ -1,14 +1,18 @@
 # Configuring cluster gRPC communication with SSL/TLS
 
-This guide provides instructions for configuring GraphDB cluster gRPC communication with SSL/TLS. It details how to 
+This guide provides instructions for configuring GraphDB cluster gRPC communication with SSL/TLS. It details how to
 configure it:
 * Using JSSE: By providing keystore and truststore.
 * Using OpenSSL: By providing certificate file, certificate chain, private key and truststore.
-* Using a certificate without chain path: By providing certificate file, private key and truststore.  
+* Using a certificate without chain path: By providing certificate file, private key and truststore.
 
-**Note:**  
-The message that indicates that the gRPC cluster security has been set up is logged at DEBUG level so your Logger 
-should be configured accordingly.
+**Note:**
+ - The message that indicates that the gRPC cluster security has been set up is logged at DEBUG level so your Logger
+   should be configured accordingly.
+ - If using standalone (self-signed) certificates for SSL/TLS configuration without a CA, and
+   the same certificate is applied across all nodes, that certificate must be added to the truststore.
+   However, if certificates are signed by a Certificate Authority (CA), the CA's root certificate
+   (or intermediate certificates, if applicable) should be present in the truststore.
 ### See more about TLS/SSL set up:
  - GraphDB configuration properties : https://graphdb.ontotext.com/documentation/10.8/directories-and-config-properties.html#cluster-properties
  - Tomcat documentation: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html
@@ -16,7 +20,7 @@ should be configured accordingly.
 
 ## Warning
 
-If cluster.tls.mode is set to TLS while one or more of the other TLS-related properties are not configured properly, 
+If cluster.tls.mode is set to TLS while one or more of the other TLS-related properties are not configured properly,
 the server may not be able to start.
 
 ## Configuring using JSSE
@@ -26,7 +30,7 @@ the server may not be able to start.
 * Keystore that contains both the private key and certificate
 * Truststore that contains the certificate to be trusted or the CA
 
-[Configuration example](jsse.yaml) 
+[Configuration example](jsse.yaml)
 
 ## Configuring using OpenSSL
 
@@ -35,7 +39,7 @@ the server may not be able to start.
 * Valid certificate chain that contains the target certificate
 * Truststore that contains the certificate to be trusted or the CA
 
-[Configuration example](openssl.yaml) 
+[Configuration example](openssl.yaml)
 
 ## Configuring using certificate without certificate chain
 
@@ -43,5 +47,5 @@ the server may not be able to start.
 * Certificate and certificate private key in PEM format.
 * Truststore that contains the certificate to be trusted or the CA
 
-[Configuration example](certWithoutChain.yaml)  
+[Configuration example](certWithoutChain.yaml)
 

--- a/examples/tomcat-security/README.md
+++ b/examples/tomcat-security/README.md
@@ -7,11 +7,15 @@ There are 3 scenarios for configuring the security of the GraphDB instance:
 - By providing a truststore - used in cases where GraphDB should trust an external service.
 
 **Note:**
-If the Tomcat server is configured with SSL/TLS it will also configure the cluster gRPC communication SSL/TLS.
+- If the Tomcat server is configured with SSL/TLS it will also configure the cluster gRPC communication SSL/TLS.
+- If using standalone (self-signed) certificates for SSL/TLS configuration without a CA, and
+  the same certificate is applied across all nodes, that certificate must be added to the truststore.
+  However, if certificates are signed by a Certificate Authority (CA), the CA's root certificate
+  (or intermediate certificates, if applicable) should be present in the truststore.
 
-**Ingress**  
-If you are using the default nginx ingress controller, you must include the following annotation to ensure proper 
-communication between the ingress and the backend:  
+**Ingress**
+If you are using the default nginx ingress controller, you must include the following annotation to ensure proper
+communication between the ingress and the backend:
 ```yaml
 ingress:
   annotations:
@@ -23,7 +27,7 @@ ingress:
 - Tomcat documentation: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html
 - Troubleshooting: https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html#Troubleshooting
 
-## Configuring using keystore and truststore 
+## Configuring using keystore and truststore
 
 **Prerequisites:**
 * Certificate and certificate private key in PEM format.


### PR DESCRIPTION
Added a note in the README files for the gRPC and Tomcat security examples stating that if certificates are signed by a CA, the CA's certificate must be present in the truststore.