### PR TITLE
feat: add support to render string Helm templates in `extraObjects`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 12.1.0
 
-## New
+### New
 
 - Updated the `extraObjects` template processing to additionally support rendering string Helm templates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 12.1.0
+
+## New
+
+- Updated the `extraObjects` template processing to additionally support rendering string Helm templates.
+
 ## Version 12.0.0
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 12.0.0
+version: 12.1.0
 appVersion: 11.0.0
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/

--- a/examples/templated-extra-objects/README.md
+++ b/examples/templated-extra-objects/README.md
@@ -1,0 +1,17 @@
+# Templated Extra Objects Example
+
+This example shows how to configure the extraObjects array with templated items
+
+## Configuration
+
+The default [values.yaml](values.yaml) in the example creates an additional configmap resource, which
+references a section from values.yaml. The additional configmap is templated with Helm and has use
+of `include` `tpl`, `range` and `if`. Other templating functions are also supported.
+
+NOTE: For templated resource in extraObjects, it needs to be a string instead of YAML object
+
+## Usage
+
+```bash
+helm upgrade --install --values ./values.yaml graphdb ontotext/graphdb
+```

--- a/examples/templated-extra-objects/values.yaml
+++ b/examples/templated-extra-objects/values.yaml
@@ -1,0 +1,45 @@
+backup:
+  enabled: true
+
+  type: local
+
+  local:
+    existingPVC: local-backups
+
+randomCM:
+  enabled: true
+  values:
+    key1: value1
+    key2: value2
+
+# Example of a simple PVC that can be used as local backup storage.
+# Ideally, you should provide something that is replicated across AZs or even regions.
+extraObjects:
+  - |
+    {{- if $.Values.randomCM.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "graphdb.fullname" $ }}-randomCM
+      namespace: {{ include "graphdb.namespace" $ }}
+      labels:
+        {{- include "graphdb.labels" $ | nindent 4 }}
+      {{- with $.Values.annotations }}
+      annotations:
+        {{- tpl (toYaml .) $ | nindent 4 }}
+      {{- end }}
+    data:
+      {{- range $key, $value := $.Values.randomCM.values }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: local-backups
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi

--- a/templates/extra-objects.yaml
+++ b/templates/extra-objects.yaml
@@ -1,4 +1,5 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- $value := typeIs "string" . | ternary . (. | toYaml) }}
+{{ tpl $value $ }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1719,5 +1719,6 @@ proxy:
 #################################
 
 # Additional objects to insert along with the release.
-# Values are processed as Helm templates.
+# Values are processed as Helm templates with tpl function.
+# Ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
 extraObjects: []


### PR DESCRIPTION
The chart can now render string templates added in `extraObjects` array in values of the chart. This change will allow users to also use helm templating functions inside the extra objects providing them more flexibility.

The render loop first test if the item in array is a string or not. If it's not a string, then it's processed via `toYaml` first.

An example values.yaml is also added to show how this feature will work