### PR TITLE
GDB-12470: Update to GraphDB 10.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 11.4.4
+
+### New
+
+- Updated to GraphDB [10.8.8](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-8)
+
 ## Version 11.4.3
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 11.4.3
-appVersion: 10.8.7
+version: 11.4.4
+appVersion: 10.8.8
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png


### PR DESCRIPTION
- Updated the Helm chart to use GraphDB version 10.8.8
- Updated the Helm chart to version 11.4.4