### PR TITLE
GDB-12439: Update to GraphDB 11.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GraphDB Helm chart release notes
 
+## Version 12.0.2
+
+### New
+
+- Updated to GraphDB [11.0.2](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-11-0-2)
+
+
 ## Version 12.0.1
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 12.0.1
-appVersion: 11.0.1
+version: 12.0.2
+appVersion: 11.0.2
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png


### PR DESCRIPTION
- Updated the Helm chart to use GraphDB version 11.0.2
- Updated the Helm chart to version 12.0.2