### PR TITLE
Merging develop/12.1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 12.1.0
 
-## New
+### New
 
 - Updated the `extraObjects` template processing to additionally support rendering string Helm templates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New
 
+- Updated to GraphDB [11.1.0](https://graphdb.ontotext.com/documentation/11.1/release-notes.html#graphdb-11-1-0)
 - Updated the `extraObjects` template processing to additionally support rendering string Helm templates.
 
 ## Version 12.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GraphDB Helm chart release notes
 
+## Version 12.1.0
+
+## New
+
+- Updated the `extraObjects` template processing to additionally support rendering string Helm templates.
+
 ## Version 12.0.3
 
 ### Fixed

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
-version: 12.0.3
-appVersion: 11.0.2
+version: 12.1.0
+appVersion: 11.1.0
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Note: If `1` is selected as node count, the launched node will be standalone and
 
 - The section `cluster.config` can be used to configure a GraphDB cluster.
 
-See more about the cluster here: https://graphdb.ontotext.com/documentation/11.0/cluster-basics.html
+See more about the cluster here: https://graphdb.ontotext.com/documentation/11.1/cluster-basics.html
 
 ### Deploying GraphDB with security
 
@@ -212,7 +212,7 @@ Note that the `provisioning` user is required when security is turned on!
 By default, if the security is turned on, GraphDB's basic security method is used. More complicated security configurations
 can be configured using additional configurations in `graphdb.properties`.
 
-See https://graphdb.ontotext.com/documentation/11.0/access-control.html
+See https://graphdb.ontotext.com/documentation/11.1/access-control.html
 
 Prior to GraphDB 10.0.0 the users and their settings were saved in the `settings.js` file.
 
@@ -231,9 +231,9 @@ Note the `settings.js` must contain `security.enabled" : true` property when sec
 GraphDB uses Logback to configure logging using the `logback.xml` file.
 The file can be provisioned before GraphDB's startup with the `configuration.logback.existingConfigmap` configuration.
 
-See https://graphdb.ontotext.com/documentation/11.0/directories-and-config-properties.html#configuration-properties
+See https://graphdb.ontotext.com/documentation/11.1/directories-and-config-properties.html#configuration-properties
 
-See https://graphdb.ontotext.com/documentation/11.0/access-control.html
+See https://graphdb.ontotext.com/documentation/11.1/access-control.html
 
 ### Importing data from existing persistent volume
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -197,7 +197,7 @@ Note: If `1` is selected as node count, the launched node will be standalone and
 
 - The section `cluster.config` can be used to configure a GraphDB cluster.
 
-See more about the cluster here: https://graphdb.ontotext.com/documentation/11.0/cluster-basics.html
+See more about the cluster here: https://graphdb.ontotext.com/documentation/11.1/cluster-basics.html
 
 ### Deploying GraphDB with security
 
@@ -212,7 +212,7 @@ Note that the `provisioning` user is required when security is turned on!
 By default, if the security is turned on, GraphDB's basic security method is used. More complicated security configurations
 can be configured using additional configurations in `graphdb.properties`.
 
-See https://graphdb.ontotext.com/documentation/11.0/access-control.html
+See https://graphdb.ontotext.com/documentation/11.1/access-control.html
 
 Prior to GraphDB 10.0.0 the users and their settings were saved in the `settings.js` file.
 
@@ -231,9 +231,9 @@ Note the `settings.js` must contain `security.enabled" : true` property when sec
 GraphDB uses Logback to configure logging using the `logback.xml` file.
 The file can be provisioned before GraphDB's startup with the `configuration.logback.existingConfigmap` configuration.
 
-See https://graphdb.ontotext.com/documentation/11.0/directories-and-config-properties.html#configuration-properties
+See https://graphdb.ontotext.com/documentation/11.1/directories-and-config-properties.html#configuration-properties
 
-See https://graphdb.ontotext.com/documentation/11.0/access-control.html
+See https://graphdb.ontotext.com/documentation/11.1/access-control.html
 
 ### Importing data from existing persistent volume
 

--- a/examples/aws/backup/README.md
+++ b/examples/aws/backup/README.md
@@ -126,4 +126,4 @@ backup:
     existingSecret: graphdb-custom-backup-options
 ```
 
-See https://graphdb.ontotext.com/documentation/11.0/backup-and-restore.html#backup-options for supported options.
+See https://graphdb.ontotext.com/documentation/11.1/backup-and-restore.html#backup-options for supported options.

--- a/examples/azure/backup/README.md
+++ b/examples/azure/backup/README.md
@@ -123,4 +123,4 @@ backup:
     existingSecret: graphdb-custom-backup-options
 ```
 
-See https://graphdb.ontotext.com/documentation/11.0/backup-and-restore.html#backup-options for supported options.
+See https://graphdb.ontotext.com/documentation/11.1/backup-and-restore.html#backup-options for supported options.

--- a/examples/configuring/README.md
+++ b/examples/configuring/README.md
@@ -10,7 +10,7 @@ and efficient setup. Additionally, it explains how to set Java arguments
 and environment variables for GraphDB.
 
 All GraphDB configuration options can be found
-[here](https://graphdb.ontotext.com/documentation/11.0/directories-and-config-properties.html#general-properties).
+[here](https://graphdb.ontotext.com/documentation/11.1/directories-and-config-properties.html#general-properties).
 
 ## Properties
 

--- a/examples/gcp/backup/README.md
+++ b/examples/gcp/backup/README.md
@@ -124,4 +124,4 @@ backup:
     existingSecret: graphdb-custom-backup-options
 ```
 
-See https://graphdb.ontotext.com/documentation/11.0/backup-and-restore.html#backup-options for supported options.
+See https://graphdb.ontotext.com/documentation/11.1/backup-and-restore.html#backup-options for supported options.

--- a/examples/grpc-security/README.md
+++ b/examples/grpc-security/README.md
@@ -14,7 +14,7 @@ configure it:
    However, if certificates are signed by a Certificate Authority (CA), the CA's root certificate
    (or intermediate certificates, if applicable) should be present in the truststore.
 ### See more about TLS/SSL set up:
- - GraphDB configuration properties : https://graphdb.ontotext.com/documentation/11.0/directories-and-config-properties.html#cluster-properties
+ - GraphDB configuration properties : https://graphdb.ontotext.com/documentation/11.1/directories-and-config-properties.html#cluster-properties
  - Tomcat documentation: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html
  - Troubleshooting: https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html#Troubleshooting
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,7 +1,7 @@
 # GraphDB External Plugins Examples
 
 This folder contains examples of how to configure GraphDB with external plugins by providing them to the classpath.
-See https://graphdb.ontotext.com/documentation/11.0/plug-in-api.html#adding-external-plugins-to-graphdb for more information and
+See https://graphdb.ontotext.com/documentation/11.1/plug-in-api.html#adding-external-plugins-to-graphdb for more information and
 configuration examples.
 
 ## Using GraphDB Persistence

--- a/examples/templated-extra-objects/README.md
+++ b/examples/templated-extra-objects/README.md
@@ -1,0 +1,17 @@
+# Templated Extra Objects Example
+
+This example shows how to configure the extraObjects array with templated items
+
+## Configuration
+
+The default [values.yaml](values.yaml) in the example creates an additional configmap resource, which
+references a section from values.yaml. The additional configmap is templated with Helm and has use
+of `include` `tpl`, `range` and `if`. Other templating functions are also supported.
+
+NOTE: For templated resource in extraObjects, it needs to be a string instead of YAML object
+
+## Usage
+
+```bash
+helm upgrade --install --values ./values.yaml graphdb ontotext/graphdb
+```

--- a/examples/templated-extra-objects/values.yaml
+++ b/examples/templated-extra-objects/values.yaml
@@ -1,0 +1,45 @@
+backup:
+  enabled: true
+
+  type: local
+
+  local:
+    existingPVC: local-backups
+
+randomCM:
+  enabled: true
+  values:
+    key1: value1
+    key2: value2
+
+# Example of a simple PVC that can be used as local backup storage.
+# Ideally, you should provide something that is replicated across AZs or even regions.
+extraObjects:
+  - |
+    {{- if $.Values.randomCM.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "graphdb.fullname" $ }}-randomCM
+      namespace: {{ include "graphdb.namespace" $ }}
+      labels:
+        {{- include "graphdb.labels" $ | nindent 4 }}
+      {{- with $.Values.annotations }}
+      annotations:
+        {{- tpl (toYaml .) $ | nindent 4 }}
+      {{- end }}
+    data:
+      {{- range $key, $value := $.Values.randomCM.values }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: local-backups
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi

--- a/examples/tomcat-security/README.md
+++ b/examples/tomcat-security/README.md
@@ -23,9 +23,9 @@ ingress:
 ```
 
 ### See more about Tomcat TLS/SSL set up:
-- GraphDB official documentation: https://graphdb.ontotext.com/documentation/11.0/encryption.html#configuring-graphdb-instance-with-ssl
+- GraphDB official documentation: https://graphdb.ontotext.com/documentation/11.1/encryption.html#configuring-a-graphdb-instance-with-ssl
 - Tomcat documentation: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html
-- Troubleshooting: https://tomcat.apache.org/tomcat-7.0-doc/ssl-howto.html#Troubleshooting
+- Troubleshooting: https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html#Troubleshooting
 
 ## Configuring using keystore and truststore
 

--- a/examples/virtualization/README.md
+++ b/examples/virtualization/README.md
@@ -1,7 +1,7 @@
 # GraphDB Virtualization Examples
 
 This folder contains examples of how to configure GraphDB's virtualization features by providing JDBC drivers to GraphDB's classpath.
-See https://graphdb.ontotext.com/documentation/11.0/virtualization.html for more information and [Ontop](https://ontop-vkg.org/guide/)
+See https://graphdb.ontotext.com/documentation/11.1/virtualization.html for more information and [Ontop](https://ontop-vkg.org/guide/)
 configuration examples.
 
 ## Using GraphDB Persistence

--- a/templates/extra-objects.yaml
+++ b/templates/extra-objects.yaml
@@ -1,4 +1,5 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- $value := typeIs "string" . | ternary . (. | toYaml) }}
+{{ tpl $value $ }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1719,5 +1719,6 @@ proxy:
 #################################
 
 # Additional objects to insert along with the release.
-# Values are processed as Helm templates.
+# Values are processed as Helm templates with tpl function.
+# Ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
 extraObjects: []

--- a/values.yaml
+++ b/values.yaml
@@ -229,7 +229,7 @@ configuration:
   #
   # References
   # - Tomcat docs: https://tomcat.apache.org/tomcat-9.0-doc/config/http.html#SSL_Support_-_Connector_-_NIO_and_NIO2_(deprecated)
-  # - GraphDB docs: https://graphdb.ontotext.com/documentation/10.7/encryption.html#configuring-graphdb-instance-with-ssl
+  # - GraphDB docs: https://graphdb.ontotext.com/documentation/11.1/encryption.html#configuring-a-graphdb-instance-with-ssl
   tls:
     # If keystore secret is provided, it enables connector security by setting the following GraphDB properties:
     # graphdb.connector.SSLEnabled = true
@@ -421,7 +421,7 @@ cluster:
     #
     # Most of the possible properties can be seen from the official tomcat connector documentation without the graphdb.raft.security prefix.
     # - Tomcat docs: https://tomcat.apache.org/tomcat-9.0-doc/config/http.html#SSL_Support_-_Certificate
-    # - GraphDB docs: https://graphdb.ontotext.com/documentation/10.7/directories-and-config-properties.html#cluster-properties
+    # - GraphDB docs: https://graphdb.ontotext.com/documentation/11.1/directories-and-config-properties.html#cluster-properties
     mode: DEFAULT
 
     keystore:


### PR DESCRIPTION
From the changelog

- Updated to GraphDB [11.1.0](https://graphdb.ontotext.com/documentation/11.1/release-notes.html#graphdb-11-1-0)
- Updated the `extraObjects` template processing to additionally support rendering string Helm templates.