### PR TITLE
Updates the versions of the GitHub Actions

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  HELM_DOCS_IMAGE: "jnorwood/helm-docs:v1.13.1@sha256:717bd8f770bd1d25ccf79c876f1420e105832f2d6bbde12170405f58f540cb2d"
+  HELM_DOCS_IMAGE: "jnorwood/helm-docs:v1.14.2@sha256:7e562b49ab6b1dbc50c3da8f2dd6ffa8a5c6bba327b1c6335cc15ce29267979c"
 
 jobs:
   documentation:
@@ -14,8 +14,7 @@ jobs:
     steps:
       - id: checkout_repository
         name: Checkout repository
-        # actions/checkout@v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,11 @@ jobs:
     steps:
       - id: checkout_repository
         name: Checkout repository
-        # actions/checkout@v4.1.1
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - id: setup_helm
         name: Setup Helm
-        # azure/setup-helm@v3.5
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.14.0
 
@@ -33,8 +31,7 @@ jobs:
 
       - id: run_trivy_config
         name: Run Trivy vulnerability scanner
-        # aquasecurity/trivy-action@v0.16.1
-        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           trivy-config: trivy.yaml
@@ -46,8 +43,7 @@ jobs:
 
       - id: run_sarif_upload
         name: Upload Trivy SARIF results
-        # github/codeql-action/upload-sarif@v2.22.9
-        uses: github/codeql-action/upload-sarif@382a50a0284c0de445104889a9d6003acb4b3c1d
+        uses: github/codeql-action/upload-sarif@bc0b696b4103f5fe60f15749af68a046868d511a #v2.25.4
         timeout-minutes: 1
         with:
           sarif_file: trivy.sarif


### PR DESCRIPTION
- There are actions which are using NodeJS v20 images. These are deprecated and soon will be removed. To keep the actions in working condition and up-to-date, we've updated all actions to their latest version that is currently available.