### PR TITLE
GDB-14975: Updated to GraphDB 11.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   Headless services default to `true` to allow cluster nodes to communicate before readiness probes pass,
   enabling proper startup sequencing during rolling upgrades.
 
+## Version 12.4.3
+
+### New
+
+- Updated to GraphDB [11.4.3](https://graphdb.ontotext.com/documentation/11.3/release-notes.html#graphdb-11-4-3)
+
 ## Version 12.4.2
 
 ### New

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ name: graphdb
 description: GraphDB is a highly efficient, scalable and robust graph database with RDF and SPARQL support.
 type: application
 version: 12.5.0
-appVersion: 11.4.2
+appVersion: 11.4.3
 kubeVersion: ^1.26.0-0
 home: https://graphdb.ontotext.com/
 icon: https://graphdb.ontotext.com/home/images/visual_Logo_GraphDB_02_12_2015.png

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml/badge.svg)](https://github.com/Ontotext-AD/graphdb-helm/actions/workflows/ci.yml)
 ![Version: 12.5.0](https://img.shields.io/badge/Version-12.5.0-informational?style=flat-square)
-![AppVersion: 11.4.2](https://img.shields.io/badge/AppVersion-11.4.2-informational?style=flat-square)
+![AppVersion: 11.4.3](https://img.shields.io/badge/AppVersion-11.4.3-informational?style=flat-square)
 
 <!--
 TODO: Add ArtifactHub badge when ready


### PR DESCRIPTION
- Updated the Helm chart to deploy GraphDB version 11.4.3
